### PR TITLE
Support for anonymous saved versions

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getdoc/GetDocResult.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getdoc/GetDocResult.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import uk.ac.ic.wlgitbridge.snapshot.base.Result;
 import uk.ac.ic.wlgitbridge.snapshot.exception.FailedConnectionException;
 import uk.ac.ic.wlgitbridge.snapshot.getdoc.exception.InvalidProjectException;
+import uk.ac.ic.wlgitbridge.snapshot.getsavedvers.WLUser;
 import uk.ac.ic.wlgitbridge.snapshot.push.exception.SnapshotPostException;
 import uk.ac.ic.wlgitbridge.snapshot.base.Request;
 import uk.ac.ic.wlgitbridge.snapshot.getdoc.exception.ProtectedProjectException;
@@ -17,8 +18,7 @@ public class GetDocResult extends Result {
     private int error;
     private int versionID;
     private String createdAt;
-    private String name;
-    private String email;
+    private WLUser user;
 
     private SnapshotPostException exception;
 
@@ -34,8 +34,7 @@ public class GetDocResult extends Result {
         }
         this.versionID = versionID;
         this.createdAt = createdAt;
-        this.name = name;
-        this.email = email;
+        this.user = new WLUser(name, email);
     }
 
     @Override
@@ -45,8 +44,8 @@ public class GetDocResult extends Result {
             jsonThis.addProperty("latestVerId", versionID);
             jsonThis.addProperty("latestVerAt", createdAt);
             JsonObject latestVerBy = new JsonObject();
-            latestVerBy.addProperty("email", email);
-            latestVerBy.addProperty("name", name);
+            latestVerBy.addProperty("email", getEmail());
+            latestVerBy.addProperty("name", getName());
             jsonThis.add("latestVerBy", latestVerBy);
         } else {
             jsonThis.addProperty("status", error);
@@ -78,15 +77,17 @@ public class GetDocResult extends Result {
         } else {
             versionID = jsonObject.get("latestVerId").getAsInt();
             createdAt = jsonObject.get("latestVerAt").getAsString();
+            String name = null;
+            String email = null;
             JsonElement latestVerBy = jsonObject.get("latestVerBy");
+
             if (latestVerBy.isJsonObject()) {
                 JsonObject userObject = latestVerBy.getAsJsonObject();
                 name = userObject.get("name").getAsString();
                 email = userObject.get("email").getAsString();
-            } else {
-                name = "Anonymous";
-                email = "anonymous@overleaf.com";
             }
+
+            user = new WLUser(name, email);
         }
     }
 
@@ -102,11 +103,11 @@ public class GetDocResult extends Result {
     }
 
     public String getName() {
-        return name;
+        return user.getName();
     }
 
     public String getEmail() {
-        return email;
+        return user.getEmail();
     }
 
 }

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getsavedvers/SnapshotInfo.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getsavedvers/SnapshotInfo.java
@@ -32,7 +32,7 @@ public class SnapshotInfo implements Comparable<SnapshotInfo> {
     }
 
     public WLUser getUser() {
-        return user;
+        return user != null ? user : new WLUser();
     }
 
     public String getCreatedAt() {

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getsavedvers/WLUser.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getsavedvers/WLUser.java
@@ -11,12 +11,17 @@ public class WLUser {
     private final String email;
 
     public WLUser() {
-        this("Anonymous", "anonymous@" + Util.getServiceName().toLowerCase() + ".com");
+        this(null, null);
     }
 
     public WLUser(String name, String email) {
-        this.name = name;
-        this.email = email;
+        if (name != null && email != null) {
+            this.name = name;
+            this.email = email;
+        } else {
+            this.name = "Anonymous";
+            this.email = "anonymous@" + Util.getServiceName().toLowerCase() + ".com";
+        }
     }
 
     public String getName() {


### PR DESCRIPTION
This fixes a case when de API sends a version without user. There was a
bug allowing to create anonymous versions in the application and we
have to support the old data.

The problem here is that SnapshotInfo classes are inflated from json
via Gson. This method does not call any constructor and, since the json
does not include the ‘user’ key, the bridge crashes because we’re not
expecting null users.

I’m not happy with this fix, but is the minimum solution that does not
affect anything else.
