### PR TITLE
Handle 401 errors as ptorected projects

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getdoc/GetDocResult.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getdoc/GetDocResult.java
@@ -65,6 +65,7 @@ public class GetDocResult extends Result {
         JsonObject jsonObject = json.getAsJsonObject();
         if (jsonObject.has("status")) {
             switch (jsonObject.get("status").getAsInt()) {
+            case 401:
             case 403:
                 exception = new ProtectedProjectException();
                 break;


### PR DESCRIPTION
We want to handle 401 errors the same way we handle 403: informing the user that the project is protected.
