### PR TITLE
Update local version after processing snapshots

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/data/model/DataStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/model/DataStore.java
@@ -42,10 +42,12 @@ public class DataStore {
 
     public void updateProjectWithName(String name, Repository repository) throws IOException, SnapshotPostException, GitAPIException {
         LinkedList<Snapshot> snapshots = snapshotFetcher.getSnapshotsForProjectAfterVersion(name, persistentStore.getLatestVersionForProject(name));
+
+        makeCommitsFromSnapshots(name, repository, snapshots);
+
         if (!snapshots.isEmpty()) {
             persistentStore.setLatestVersionForProject(name, snapshots.getLast().getVersionID());
         }
-        makeCommitsFromSnapshots(name, repository, snapshots);
     }
 
     private void makeCommitsFromSnapshots(String name, Repository repository, List<Snapshot> snapshots) throws IOException, GitAPIException {


### PR DESCRIPTION
We observed some corrupted repos which seem to have the files from and old version but the local version stored in the sqlite is more recent. 

Probably, this is because some file-fetching failed and we updated the version before all the files were actually commited.

Ensuring the commits are done before updating the local version should prevent this corrupted projects.
