### PR TITLE
Provide sensible error message for LargeObjectException

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/data/model/DataStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/model/DataStore.java
@@ -53,7 +53,7 @@ public class DataStore {
         }
     }
 
-    private void makeCommitsFromSnapshots(String name, Repository repository, List<Snapshot> snapshots) throws IOException, GitAPIException {
+    private void makeCommitsFromSnapshots(String name, Repository repository, List<Snapshot> snapshots) throws IOException, GitAPIException, SnapshotPostException {
         for (Snapshot snapshot : snapshots) {
             List<RawFile> files = new LinkedList<RawFile>();
             files.addAll(snapshot.getSrcs());

--- a/src/main/java/uk/ac/ic/wlgitbridge/data/model/ResourceFetcher.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/model/ResourceFetcher.java
@@ -10,6 +10,7 @@ import uk.ac.ic.wlgitbridge.data.model.db.PersistentStore;
 import uk.ac.ic.wlgitbridge.git.util.RepositoryObjectTreeWalker;
 import uk.ac.ic.wlgitbridge.snapshot.base.Request;
 import uk.ac.ic.wlgitbridge.snapshot.exception.FailedConnectionException;
+import uk.ac.ic.wlgitbridge.snapshot.push.exception.SnapshotPostException;
 import uk.ac.ic.wlgitbridge.util.Util;
 
 import java.io.ByteArrayOutputStream;
@@ -28,7 +29,7 @@ public class ResourceFetcher {
         this.persistentStore = persistentStore;
     }
 
-    public RawFile get(String projectName, String url, String newPath, Repository repository, Map<String, byte[]> fetchedUrls) throws IOException {
+    public RawFile get(String projectName, String url, String newPath, Repository repository, Map<String, byte[]> fetchedUrls) throws IOException, SnapshotPostException {
         String path = persistentStore.getPathForURLInProject(projectName, url);
         byte[] contents;
         if (path == null) {

--- a/src/main/java/uk/ac/ic/wlgitbridge/git/exception/SizeLimitExceededException.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/git/exception/SizeLimitExceededException.java
@@ -1,0 +1,37 @@
+package uk.ac.ic.wlgitbridge.git.exception;
+
+import com.google.gson.JsonElement;
+import uk.ac.ic.wlgitbridge.snapshot.push.exception.SnapshotPostException;
+import uk.ac.ic.wlgitbridge.util.Util;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class SizeLimitExceededException extends SnapshotPostException {
+
+    private static String path = null;
+
+    public SizeLimitExceededException(String path) {
+        super();
+        this.path = path;
+    }
+
+    @Override
+    public String getMessage() {
+        return "file too big";
+    }
+
+    @Override
+    public List<String> getDescriptionLines() {
+        String filename = path != null ? "File '" + path + "' is" : "There's a file";
+        return Arrays.asList(
+            filename + " too large to push to " + Util.getServiceName() + " via git",
+            "the recommended maximum file size is 15MiB"
+        );
+    }
+
+    @Override
+    public void fromJSON(JsonElement json) {
+
+    }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/git/handler/hook/WriteLatexPutHook.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/git/handler/hook/WriteLatexPutHook.java
@@ -89,13 +89,13 @@ public class WriteLatexPutHook implements PreReceiveHook {
         }
     }
 
-    private RawDirectory getPushedDirectoryContents(Repository repository, ReceiveCommand receiveCommand) throws IOException {
+    private RawDirectory getPushedDirectoryContents(Repository repository, ReceiveCommand receiveCommand) throws IOException, SnapshotPostException {
         return new RepositoryObjectTreeWalker(repository,
                                               receiveCommand.getNewId())
                .getDirectoryContents();
     }
 
-    private RawDirectory getOldDirectoryContents(Repository repository) throws IOException {
+    private RawDirectory getOldDirectoryContents(Repository repository) throws IOException, SnapshotPostException {
         return new RepositoryObjectTreeWalker(repository).getDirectoryContents();
     }
 


### PR DESCRIPTION
### Description

Usually, when a user pushes a heavy set of changes the expected error is a timeout from Overleaf API. But if a single file is too big to be processed (does not fit in memory) a `LargeObjectException` is thrown, leaving a stacktrace in `err.log` but returning a generic error to user:

```
$ git push overleaf master
Counting objects: 1420, done.
Delta compression using up to 8 threads.
Compressing objects: 100% (834/834), done.
Writing objects: 100% (1419/1419), 143.32 MiB | 9.72 MiB/s, done.
Total 1419 (delta 696), reused 1185 (delta 569)
remote: Resolving deltas: 100% (696/696)
remote: error: internal error
remote: hint: There was an internal error with the Git server.
remote: hint: Please contact Overleaf.
To https://git.overleaf.com/project
! [remote rejected] master -> master (internal error)
error: failed to push some refs to 'https://git.overleaf.com/project'
```

This PR includes a new type of exception with message and description that will be shown on the user's console when this happens.
### Review

As usual, it's worth to review my wording. With the exception I'm adding the user will see this output:

```
$ git push
Counting objects: 4, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (3/3), done.
Writing objects: 100% (4/4), 72.02 KiB | 0 bytes/s, done.
Total 4 (delta 0), reused 0 (delta 0)
remote: error: file too big
remote: hint: File 'test/output2.dat' is too big to be pushed.
To http://localhost:8000/243sdfmwq
 ! [remote rejected] master -> master (file too big)
error: failed to push some refs to 'http://localhost:8000/243sdfmwq'

```
### Risks and Mitigations
- The file's max size is not defined. As I understand the original exception is thrown where we hit an `OutOfMemory` error and the limit may vary depending on the jvm config or the state of the server. Maybe we can come to a better wording to reflect this.
- I'm not sure about adding a really big file to test cases just to test that. If you think it's worth it, we can do (I think we have a lot of more common behaviour not tested).
### Manual Testing Checklist
- [x] Create a repository and try to push a big file (64mb). Returns the expected error.
- [x] We can still push small sized files.
