### PR TITLE
Config git for tests

### DIFF
--- a/src/test/java/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest.java
@@ -112,11 +112,8 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process git = runtime.exec("git clone http://127.0.0.1:33857/testproj.git", null, dir);
-        int exitCode = git.waitFor();
+        File testprojDir = cloneRepository("testproj", 33857, dir);
         wlgb.stop();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCode);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canCloneARepository/state/testproj"), testprojDir.toPath()));
     }
 
@@ -130,16 +127,10 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process git1 = runtime.exec("git clone http://127.0.0.1:33858/testproj1.git", null, dir);
-        int exitCode1 = git1.waitFor();
-        Process git2 = runtime.exec("git clone http://127.0.0.1:33858/testproj2.git", null, dir);
-        int exitCode2 = git2.waitFor();
+        File testproj1Dir = cloneRepository("testproj1", 33858, dir);
+        File testproj2Dir = cloneRepository("testproj2", 33858, dir);
         wlgb.stop();
-        File testproj1Dir = new File(dir, "testproj1");
-        File testproj2Dir = new File(dir, "testproj2");
-        assertEquals(0, exitCode1);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canCloneMultipleRepositories/state/testproj1"), testproj1Dir.toPath()));
-        assertEquals(0, exitCode2);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canCloneMultipleRepositories/state/testproj2"), testproj2Dir.toPath()));
     }
 
@@ -153,10 +144,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process gitBase = runtime.exec("git clone http://127.0.0.1:33859/testproj.git", null, dir);
-        int exitCodeBase = gitBase.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCodeBase);
+        File testprojDir = cloneRepository("testproj", 33859, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canPullAModifiedTexFile/base/testproj"), testprojDir.toPath()));
         server.setState(states.get("canPullAModifiedTexFile").get("withModifiedTexFile"));
         Process gitWithModifiedTexFile = runtime.exec("git pull", null, testprojDir);
@@ -176,10 +164,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process gitBase = runtime.exec("git clone http://127.0.0.1:33860/testproj.git", null, dir);
-        int exitCodeBase = gitBase.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCodeBase);
+        File testprojDir = cloneRepository("testproj", 33860, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canPullADeletedTexFile/base/testproj"), testprojDir.toPath()));
         server.setState(states.get("canPullADeletedTexFile").get("withDeletedTexFile"));
         Process gitWithDeletedTexFile = runtime.exec("git pull", null, testprojDir);
@@ -199,10 +184,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process gitBase = runtime.exec("git clone http://127.0.0.1:33862/testproj.git", null, dir);
-        int exitCodeBase = gitBase.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCodeBase);
+        File testprojDir = cloneRepository("testproj", 33862, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canPullAModifiedBinaryFile/base/testproj"), testprojDir.toPath()));
         server.setState(states.get("canPullAModifiedBinaryFile").get("withModifiedBinaryFile"));
         Process gitWithModifiedBinaryFile = runtime.exec("git pull", null, testprojDir);
@@ -222,10 +204,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process gitBase = runtime.exec("git clone http://127.0.0.1:33863/testproj.git", null, dir);
-        int exitCodeBase = gitBase.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCodeBase);
+        File testprojDir = cloneRepository("testproj", 33863, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canPullADeletedBinaryFile/base/testproj"), testprojDir.toPath()));
         server.setState(states.get("canPullADeletedBinaryFile").get("withDeletedBinaryFile"));
         Process gitWithDeletedBinaryFile = runtime.exec("git pull", null, testprojDir);
@@ -245,10 +224,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process gitBase = runtime.exec("git clone http://127.0.0.1:44001/testproj.git", null, dir);
-        int exitCodeBase = gitBase.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCodeBase);
+        File testprojDir = cloneRepository("testproj", 44001, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canPullADuplicateBinaryFile/base/testproj"), testprojDir.toPath()));
         server.setState(states.get("canPullADuplicateBinaryFile").get("withDuplicateBinaryFile"));
         Process gitWithDeletedBinaryFile = runtime.exec("git pull", null, testprojDir);
@@ -268,11 +244,8 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process git = runtime.exec("git clone http://127.0.0.1:44002/testproj.git", null, dir);
-        int exitCode = git.waitFor();
+        File testprojDir = cloneRepository("testproj", 44002, dir);
         wlgb.stop();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCode);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canCloneDuplicateBinaryFiles/state/testproj"), testprojDir.toPath()));
     }
 
@@ -286,10 +259,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process gitBase = runtime.exec("git clone http://127.0.0.1:44003/testproj.git", null, dir);
-        int exitCodeBase = gitBase.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCodeBase);
+        File testprojDir = cloneRepository("testproj", 44003, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canPullUpdatedBinaryFiles/base/testproj"), testprojDir.toPath()));
         server.setState(states.get("canPullUpdatedBinaryFiles").get("withUpdatedBinaryFiles"));
         Process gitWithDeletedBinaryFile = runtime.exec("git pull", null, testprojDir);
@@ -309,10 +279,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process gitBase = runtime.exec("git clone http://127.0.0.1:33864/testproj.git", null, dir);
-        int exitCodeBase = gitBase.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCodeBase);
+        File testprojDir = cloneRepository("testproj", 33864, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canPullAModifiedNestedFile/base/testproj"), testprojDir.toPath()));
         server.setState(states.get("canPullAModifiedNestedFile").get("withModifiedNestedFile"));
         Process gitWithModifiedNestedFile = runtime.exec("git pull", null, testprojDir);
@@ -332,10 +299,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process gitBase = runtime.exec("git clone http://127.0.0.1:33865/testproj.git", null, dir);
-        int exitCodeBase = gitBase.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCodeBase);
+        File testprojDir = cloneRepository("testproj", 33865, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canPullDeletedNestedFiles/base/testproj"), testprojDir.toPath()));
         server.setState(states.get("canPullDeletedNestedFiles").get("withDeletedNestedFiles"));
         Process gitWithDeletedBinaryFile = runtime.exec("git pull", null, testprojDir);
@@ -355,10 +319,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process git = runtime.exec("git clone http://127.0.0.1:33866/testproj.git", null, dir);
-        int exitCode = git.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCode);
+        File testprojDir = cloneRepository("testproj", 33866, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canPushFilesSuccessfully/state/testproj"), testprojDir.toPath()));
         runtime.exec("touch push.tex", null, testprojDir).waitFor();
         runtime.exec("git add -A", null, testprojDir).waitFor();
@@ -389,10 +350,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process git = runtime.exec("git clone http://127.0.0.1:33867/testproj.git", null, dir);
-        int exitCode = git.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCode);
+        File testprojDir = cloneRepository("testproj", 33867, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/pushFailsOnFirstStageOutOfDate/state/testproj"), testprojDir.toPath()));
         runtime.exec("touch push.tex", null, testprojDir).waitFor();
         runtime.exec("git add -A", null, testprojDir).waitFor();
@@ -424,10 +382,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process git = runtime.exec("git clone http://127.0.0.1:33868/testproj.git", null, dir);
-        int exitCode = git.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCode);
+        File testprojDir = cloneRepository("testproj", 33868, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/pushFailsOnSecondStageOutOfDate/state/testproj"), testprojDir.toPath()));
         runtime.exec("touch push.tex", null, testprojDir).waitFor();
         runtime.exec("git add -A", null, testprojDir).waitFor();
@@ -463,10 +418,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process git = runtime.exec("git clone http://127.0.0.1:33869/testproj.git", null, dir);
-        int exitCode = git.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCode);
+        File testprojDir = cloneRepository("testproj", 33869, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/pushFailsOnInvalidFiles/state/testproj"), testprojDir.toPath()));
         runtime.exec("touch push.tex", null, testprojDir).waitFor();
         runtime.exec("git add -A", null, testprojDir).waitFor();
@@ -500,10 +452,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process git = runtime.exec("git clone http://127.0.0.1:33870/testproj.git", null, dir);
-        int exitCode = git.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCode);
+        File testprojDir = cloneRepository("testproj", 33870, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/pushFailsOnInvalidProject/state/testproj"), testprojDir.toPath()));
         runtime.exec("touch push.tex", null, testprojDir).waitFor();
         runtime.exec("git add -A", null, testprojDir).waitFor();
@@ -538,10 +487,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process git = runtime.exec("git clone http://127.0.0.1:33871/testproj.git", null, dir);
-        int exitCode = git.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCode);
+        File testprojDir = cloneRepository("testproj", 33871, dir);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/pushFailsOnUnexpectedError/state/testproj"), testprojDir.toPath()));
         runtime.exec("touch push.tex", null, testprojDir).waitFor();
         runtime.exec("git add -A", null, testprojDir).waitFor();
@@ -574,10 +520,7 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         File dir = folder.newFolder();
-        Process git = runtime.exec("git clone http://127.0.0.1:33872/testproj.git", null, dir);
-        int exitCode = git.waitFor();
-        File testprojDir = new File(dir, "testproj");
-        assertEquals(0, exitCode);
+        File testprojDir = cloneRepository("testproj", 33872, dir);
 
         // try to push invalid file; it should fail
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/pushSucceedsAfterRemovingInvalidFiles/invalidState/testproj"), testprojDir.toPath()));
@@ -599,6 +542,19 @@ public class WLGitBridgeIntegrationTest {
         wlgb.stop();
         assertEquals(0, pushExitCode);
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/pushSucceedsAfterRemovingInvalidFiles/validState/testproj"), testprojDir.toPath()));
+    }
+
+    private File cloneRepository(String repositoryName, int port, File dir) throws IOException, InterruptedException {
+        String repo = "git clone http://127.0.0.1:" + port + "/" + repositoryName + ".git";
+        assertEquals(0, runtime.exec(repo, null, dir).waitFor());
+
+        File repositoryDir = new File(dir, repositoryName);
+
+        assertEquals(0, runtime.exec("git config user.name TEST", null, repositoryDir).waitFor());
+        assertEquals(0, runtime.exec("git config user.email test@test.com", null, repositoryDir).waitFor());
+        assertEquals(0, runtime.exec("git config push.default matching", null, repositoryDir).waitFor());
+
+        return repositoryDir;
     }
 
     private String makeConfigFile(int port, int apiPort) throws IOException {

--- a/src/test/java/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest.java
@@ -29,75 +29,74 @@ public class WLGitBridgeIntegrationTest {
 
     private Runtime runtime = Runtime.getRuntime();
 
-    private Map<String, Map<String, SnapshotAPIState>> states =
-            new HashMap<String, Map<String, SnapshotAPIState>>() {{
-                put("canCloneARepository", new HashMap<String, SnapshotAPIState>() {{
-                    put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/canCloneARepository/state/state.json")).build());
-                }});
-                put("canCloneMultipleRepositories", new HashMap<String, SnapshotAPIState>() {{
-                    put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/canCloneMultipleRepositories/state/state.json")).build());
-                }});
-                put("cannotCloneAProtectedProject", new HashMap<String, SnapshotAPIState>() {{
-                    put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/cannotCloneAProtectedProject/state/state.json")).build());
-                }});
-                put("canPullAModifiedTexFile", new HashMap<String, SnapshotAPIState>() {{
-                    put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedTexFile/base/state.json")).build());
-                    put("withModifiedTexFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedTexFile/withModifiedTexFile/state.json")).build());
-                }});
-                put("canPullADeletedTexFile", new HashMap<String, SnapshotAPIState>() {{
-                    put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADeletedTexFile/base/state.json")).build());
-                    put("withDeletedTexFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADeletedTexFile/withDeletedTexFile/state.json")).build());
-                }});
-                put("canPullAModifiedBinaryFile", new HashMap<String, SnapshotAPIState>() {{
-                    put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedBinaryFile/base/state.json")).build());
-                    put("withModifiedBinaryFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedBinaryFile/withModifiedBinaryFile/state.json")).build());
-                }});
-                put("canPullADeletedBinaryFile", new HashMap<String, SnapshotAPIState>() {{
-                    put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADeletedBinaryFile/base/state.json")).build());
-                    put("withDeletedBinaryFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADeletedBinaryFile/withDeletedBinaryFile/state.json")).build());
-                }});
-                put("canPullADuplicateBinaryFile", new HashMap<String, SnapshotAPIState>() {{
-                    put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADuplicateBinaryFile/base/state.json")).build());
-                    put("withDuplicateBinaryFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADuplicateBinaryFile/withDuplicateBinaryFile/state.json")).build());
-                }});
-                put("canCloneDuplicateBinaryFiles", new HashMap<String, SnapshotAPIState>() {{
-                    put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/canCloneDuplicateBinaryFiles/state/state.json")).build());
-                }});
-                put("canPullUpdatedBinaryFiles", new HashMap<String, SnapshotAPIState>() {{
-                    put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullUpdatedBinaryFiles/base/state.json")).build());
-                    put("withUpdatedBinaryFiles", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullUpdatedBinaryFiles/withUpdatedBinaryFiles/state.json")).build());
-                }});
-                put("canPullAModifiedNestedFile", new HashMap<String, SnapshotAPIState>() {{
-                    put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedNestedFile/base/state.json")).build());
-                    put("withModifiedNestedFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedNestedFile/withModifiedNestedFile/state.json")).build());
-                }});
-                put("canPullDeletedNestedFiles", new HashMap<String, SnapshotAPIState>() {{
-                    put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullDeletedNestedFiles/base/state.json")).build());
-                    put("withDeletedNestedFiles", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullDeletedNestedFiles/withDeletedNestedFiles/state.json")).build());
-                }});
-                put("canPushFilesSuccessfully", new HashMap<String, SnapshotAPIState>() {{
-                    put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/canPushFilesSuccessfully/state/state.json")).build());
-                }});
-                put("pushFailsOnFirstStageOutOfDate", new HashMap<String, SnapshotAPIState>() {{
-                    put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/pushFailsOnFirstStageOutOfDate/state/state.json")).build());
-                }});
-                put("pushFailsOnSecondStageOutOfDate", new HashMap<String, SnapshotAPIState>() {{
-                    put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/pushFailsOnSecondStageOutOfDate/state/state.json")).build());
-                }});
-                put("pushFailsOnInvalidFiles", new HashMap<String, SnapshotAPIState>() {{
-                    put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/pushFailsOnInvalidFiles/state/state.json")).build());
-                }});
-                put("pushFailsOnInvalidProject", new HashMap<String, SnapshotAPIState>() {{
-                    put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/pushFailsOnInvalidProject/state/state.json")).build());
-                }});
-                put("pushFailsOnUnexpectedError", new HashMap<String, SnapshotAPIState>() {{
-                    put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/pushFailsOnUnexpectedError/state/state.json")).build());
-                }});
-                put("pushSucceedsAfterRemovingInvalidFiles", new HashMap<String, SnapshotAPIState>() {{
-                    put("invalidState", new SnapshotAPIStateBuilder(getResourceAsStream("/pushSucceedsAfterRemovingInvalidFiles/invalidState/state.json")).build());
-                    put("validState", new SnapshotAPIStateBuilder(getResourceAsStream("/pushSucceedsAfterRemovingInvalidFiles/validState/state.json")).build());
-                }});
-            }};
+    private Map<String, Map<String, SnapshotAPIState>> states = new HashMap<String, Map<String, SnapshotAPIState>>() {{
+        put("canCloneARepository", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/canCloneARepository/state/state.json")).build());
+        }});
+        put("canCloneMultipleRepositories", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/canCloneMultipleRepositories/state/state.json")).build());
+        }});
+        put("cannotCloneAProtectedProject", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/cannotCloneAProtectedProject/state/state.json")).build());
+        }});
+        put("canPullAModifiedTexFile", new HashMap<String, SnapshotAPIState>() {{
+            put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedTexFile/base/state.json")).build());
+            put("withModifiedTexFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedTexFile/withModifiedTexFile/state.json")).build());
+        }});
+        put("canPullADeletedTexFile", new HashMap<String, SnapshotAPIState>() {{
+            put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADeletedTexFile/base/state.json")).build());
+            put("withDeletedTexFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADeletedTexFile/withDeletedTexFile/state.json")).build());
+        }});
+        put("canPullAModifiedBinaryFile", new HashMap<String, SnapshotAPIState>() {{
+            put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedBinaryFile/base/state.json")).build());
+            put("withModifiedBinaryFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedBinaryFile/withModifiedBinaryFile/state.json")).build());
+        }});
+        put("canPullADeletedBinaryFile", new HashMap<String, SnapshotAPIState>() {{
+            put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADeletedBinaryFile/base/state.json")).build());
+            put("withDeletedBinaryFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADeletedBinaryFile/withDeletedBinaryFile/state.json")).build());
+        }});
+        put("canPullADuplicateBinaryFile", new HashMap<String, SnapshotAPIState>() {{
+            put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADuplicateBinaryFile/base/state.json")).build());
+            put("withDuplicateBinaryFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullADuplicateBinaryFile/withDuplicateBinaryFile/state.json")).build());
+        }});
+        put("canCloneDuplicateBinaryFiles", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/canCloneDuplicateBinaryFiles/state/state.json")).build());
+        }});
+        put("canPullUpdatedBinaryFiles", new HashMap<String, SnapshotAPIState>() {{
+            put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullUpdatedBinaryFiles/base/state.json")).build());
+            put("withUpdatedBinaryFiles", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullUpdatedBinaryFiles/withUpdatedBinaryFiles/state.json")).build());
+        }});
+        put("canPullAModifiedNestedFile", new HashMap<String, SnapshotAPIState>() {{
+            put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedNestedFile/base/state.json")).build());
+            put("withModifiedNestedFile", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullAModifiedNestedFile/withModifiedNestedFile/state.json")).build());
+        }});
+        put("canPullDeletedNestedFiles", new HashMap<String, SnapshotAPIState>() {{
+            put("base", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullDeletedNestedFiles/base/state.json")).build());
+            put("withDeletedNestedFiles", new SnapshotAPIStateBuilder(getResourceAsStream("/canPullDeletedNestedFiles/withDeletedNestedFiles/state.json")).build());
+        }});
+        put("canPushFilesSuccessfully", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/canPushFilesSuccessfully/state/state.json")).build());
+        }});
+        put("pushFailsOnFirstStageOutOfDate", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/pushFailsOnFirstStageOutOfDate/state/state.json")).build());
+        }});
+        put("pushFailsOnSecondStageOutOfDate", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/pushFailsOnSecondStageOutOfDate/state/state.json")).build());
+        }});
+        put("pushFailsOnInvalidFiles", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/pushFailsOnInvalidFiles/state/state.json")).build());
+        }});
+        put("pushFailsOnInvalidProject", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/pushFailsOnInvalidProject/state/state.json")).build());
+        }});
+        put("pushFailsOnUnexpectedError", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/pushFailsOnUnexpectedError/state/state.json")).build());
+        }});
+        put("pushSucceedsAfterRemovingInvalidFiles", new HashMap<String, SnapshotAPIState>() {{
+            put("invalidState", new SnapshotAPIStateBuilder(getResourceAsStream("/pushSucceedsAfterRemovingInvalidFiles/invalidState/state.json")).build());
+            put("validState", new SnapshotAPIStateBuilder(getResourceAsStream("/pushSucceedsAfterRemovingInvalidFiles/validState/state.json")).build());
+        }});
+    }};
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -108,7 +107,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canCloneARepository").get("state"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33857, 3857)
+            makeConfigFile(33857, 3857)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -123,7 +122,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canCloneMultipleRepositories").get("state"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33858, 3858)
+            makeConfigFile(33858, 3858)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -140,7 +139,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canPullAModifiedTexFile").get("base"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33859, 3859)
+            makeConfigFile(33859, 3859)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -160,7 +159,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canPullADeletedTexFile").get("base"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33860, 3860)
+            makeConfigFile(33860, 3860)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -180,7 +179,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canPullAModifiedBinaryFile").get("base"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33862, 3862)
+            makeConfigFile(33862, 3862)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -200,7 +199,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canPullADeletedBinaryFile").get("base"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33863, 3863)
+            makeConfigFile(33863, 3863)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -220,7 +219,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canPullADuplicateBinaryFile").get("base"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(44001, 4001)
+            makeConfigFile(44001, 4001)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -240,7 +239,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canCloneDuplicateBinaryFiles").get("state"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(44002, 4002)
+            makeConfigFile(44002, 4002)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -255,7 +254,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canPullUpdatedBinaryFiles").get("base"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(44003, 4003)
+            makeConfigFile(44003, 4003)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -275,7 +274,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canPullAModifiedNestedFile").get("base"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33864, 3864)
+            makeConfigFile(33864, 3864)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -295,7 +294,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canPullDeletedNestedFiles").get("base"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33865, 3865)
+            makeConfigFile(33865, 3865)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -315,7 +314,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("canPushFilesSuccessfully").get("state"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33866, 3866)
+            makeConfigFile(33866, 3866)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -330,15 +329,14 @@ public class WLGitBridgeIntegrationTest {
         assertEquals(0, pushExitCode);
     }
 
-
     private static final String EXPECTED_OUT_PUSH_OUT_OF_DATE_FIRST =
-            "To http://127.0.0.1:33867/testproj.git\n" +
-            " ! [rejected]        master -> master (non-fast-forward)\n" +
-            "error: failed to push some refs to 'http://127.0.0.1:33867/testproj.git'\n" +
-            "hint: Updates were rejected because the tip of your current branch is behind\n" +
-            "hint: its remote counterpart. Integrate the remote changes (e.g.\n" +
-            "hint: 'git pull ...') before pushing again.\n" +
-            "hint: See the 'Note about fast-forwards' in 'git push --help' for details.\n";
+      "To http://127.0.0.1:33867/testproj.git\n" +
+      " ! [rejected]        master -> master (non-fast-forward)\n" +
+      "error: failed to push some refs to 'http://127.0.0.1:33867/testproj.git'\n" +
+      "hint: Updates were rejected because the tip of your current branch is behind\n" +
+      "hint: its remote counterpart. Integrate the remote changes (e.g.\n" +
+      "hint: 'git pull ...') before pushing again.\n" +
+      "hint: See the 'Note about fast-forwards' in 'git push --help' for details.\n";
 
     @Test
     public void pushFailsOnFirstStageOutOfDate() throws IOException, GitAPIException, InterruptedException {
@@ -346,7 +344,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("pushFailsOnFirstStageOutOfDate").get("state"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33867, 3867)
+            makeConfigFile(33867, 3867)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -362,15 +360,14 @@ public class WLGitBridgeIntegrationTest {
         assertEquals(EXPECTED_OUT_PUSH_OUT_OF_DATE_FIRST, Util.fromStream(gitPush.getErrorStream(), 2));
     }
 
-
     private static final String EXPECTED_OUT_PUSH_OUT_OF_DATE_SECOND =
-            "To http://127.0.0.1:33868/testproj.git\n" +
-                    " ! [rejected]        master -> master (non-fast-forward)\n" +
-                    "error: failed to push some refs to 'http://127.0.0.1:33868/testproj.git'\n" +
-                    "hint: Updates were rejected because the tip of your current branch is behind\n" +
-                    "hint: its remote counterpart. Integrate the remote changes (e.g.\n" +
-                    "hint: 'git pull ...') before pushing again.\n" +
-                    "hint: See the 'Note about fast-forwards' in 'git push --help' for details.\n";
+      "To http://127.0.0.1:33868/testproj.git\n" +
+      " ! [rejected]        master -> master (non-fast-forward)\n" +
+      "error: failed to push some refs to 'http://127.0.0.1:33868/testproj.git'\n" +
+      "hint: Updates were rejected because the tip of your current branch is behind\n" +
+      "hint: its remote counterpart. Integrate the remote changes (e.g.\n" +
+      "hint: 'git pull ...') before pushing again.\n" +
+      "hint: See the 'Note about fast-forwards' in 'git push --help' for details.\n";
 
     @Test
     public void pushFailsOnSecondStageOutOfDate() throws IOException, GitAPIException, InterruptedException {
@@ -378,7 +375,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("pushFailsOnSecondStageOutOfDate").get("state"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33868, 3868)
+            makeConfigFile(33868, 3868)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -394,19 +391,17 @@ public class WLGitBridgeIntegrationTest {
         assertEquals(EXPECTED_OUT_PUSH_OUT_OF_DATE_SECOND, Util.fromStream(gitPush.getErrorStream(), 2));
     }
 
-
-    private static final List<String> EXPECTED_OUT_PUSH_INVALID_FILES =
-            Arrays.asList(
-                    "remote: error: invalid files",
-                    "remote: hint: You have 4 invalid files in your Overleaf project:",
-                    "remote: hint: file1.invalid (error)",
-                    "remote: hint: file2.exe (invalid file extension)",
-                    "remote: hint: hello world.png (rename to: hello_world.png)",
-                    "remote: hint: an image.jpg (rename to: an_image.jpg)",
-                    "To http://127.0.0.1:33869/testproj.git",
-                    "! [remote rejected] master -> master (invalid files)",
-                    "error: failed to push some refs to 'http://127.0.0.1:33869/testproj.git'"
-            );
+    private static final List<String> EXPECTED_OUT_PUSH_INVALID_FILES = Arrays.asList(
+        "remote: error: invalid files",
+        "remote: hint: You have 4 invalid files in your Overleaf project:",
+        "remote: hint: file1.invalid (error)",
+        "remote: hint: file2.exe (invalid file extension)",
+        "remote: hint: hello world.png (rename to: hello_world.png)",
+        "remote: hint: an image.jpg (rename to: an_image.jpg)",
+        "To http://127.0.0.1:33869/testproj.git",
+        "! [remote rejected] master -> master (invalid files)",
+        "error: failed to push some refs to 'http://127.0.0.1:33869/testproj.git'"
+    );
 
     @Test
     public void pushFailsOnInvalidFiles() throws IOException, GitAPIException, InterruptedException {
@@ -414,7 +409,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("pushFailsOnInvalidFiles").get("state"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33869, 3869)
+            makeConfigFile(33869, 3869)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -431,16 +426,14 @@ public class WLGitBridgeIntegrationTest {
         assertEquals(EXPECTED_OUT_PUSH_INVALID_FILES, actual);
     }
 
-
-    private static final List<String> EXPECTED_OUT_PUSH_INVALID_PROJECT =
-            Arrays.asList(
-                    "remote: error: invalid project",
-                    "remote: hint: project: no main file",
-                    "remote: hint: The project would have no (editable) main .tex file.",
-                    "To http://127.0.0.1:33870/testproj.git",
-                    "! [remote rejected] master -> master (invalid project)",
-                    "error: failed to push some refs to 'http://127.0.0.1:33870/testproj.git'"
-            );
+    private static final List<String> EXPECTED_OUT_PUSH_INVALID_PROJECT = Arrays.asList(
+        "remote: error: invalid project",
+        "remote: hint: project: no main file",
+        "remote: hint: The project would have no (editable) main .tex file.",
+        "To http://127.0.0.1:33870/testproj.git",
+        "! [remote rejected] master -> master (invalid project)",
+        "error: failed to push some refs to 'http://127.0.0.1:33870/testproj.git'"
+    );
 
     @Test
     public void pushFailsOnInvalidProject() throws IOException, GitAPIException, InterruptedException {
@@ -448,7 +441,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("pushFailsOnInvalidProject").get("state"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33870, 3870)
+            makeConfigFile(33870, 3870)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -465,16 +458,14 @@ public class WLGitBridgeIntegrationTest {
         assertEquals(EXPECTED_OUT_PUSH_INVALID_PROJECT, actual);
     }
 
-
-    private static final List<String> EXPECTED_OUT_PUSH_UNEXPECTED_ERROR =
-            Arrays.asList(
-                    "remote: error: Overleaf error",
-                    "remote: hint: There was an internal error with the Overleaf server.",
-                    "remote: hint: Please contact Overleaf.",
-                    "To http://127.0.0.1:33871/testproj.git",
-                    "! [remote rejected] master -> master (Overleaf error)",
-                    "error: failed to push some refs to 'http://127.0.0.1:33871/testproj.git'"
-            );
+    private static final List<String> EXPECTED_OUT_PUSH_UNEXPECTED_ERROR = Arrays.asList(
+        "remote: error: Overleaf error",
+        "remote: hint: There was an internal error with the Overleaf server.",
+        "remote: hint: Please contact Overleaf.",
+        "To http://127.0.0.1:33871/testproj.git",
+        "! [remote rejected] master -> master (Overleaf error)",
+        "error: failed to push some refs to 'http://127.0.0.1:33871/testproj.git'"
+    );
 
     /* this one prints a stack trace */
     @Test
@@ -483,7 +474,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("pushFailsOnUnexpectedError").get("state"));
         GitBridgeApp wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33871, 3871)
+            makeConfigFile(33871, 3871)
         });
         wlgb.run();
         File dir = folder.newFolder();
@@ -500,15 +491,14 @@ public class WLGitBridgeIntegrationTest {
         assertEquals(EXPECTED_OUT_PUSH_UNEXPECTED_ERROR, actual);
     }
 
-    private static final List<String> EXPECTED_OUT_PUSH_INVALID_EXE_FILE =
-        Arrays.asList(
-                "remote: error: invalid files",
-                "remote: hint: You have 1 invalid files in your Overleaf project:",
-                "remote: hint: file1.exe (invalid file extension)",
-                "To http://127.0.0.1:33872/testproj.git",
-                "! [remote rejected] master -> master (invalid files)",
-                "error: failed to push some refs to 'http://127.0.0.1:33872/testproj.git'"
-        );
+    private static final List<String> EXPECTED_OUT_PUSH_INVALID_EXE_FILE = Arrays.asList(
+        "remote: error: invalid files",
+        "remote: hint: You have 1 invalid files in your Overleaf project:",
+        "remote: hint: file1.exe (invalid file extension)",
+        "To http://127.0.0.1:33872/testproj.git",
+        "! [remote rejected] master -> master (invalid files)",
+        "error: failed to push some refs to 'http://127.0.0.1:33872/testproj.git'"
+    );
 
     @Test
     public void pushSucceedsAfterRemovingInvalidFiles() throws IOException, GitAPIException, InterruptedException {
@@ -562,19 +552,19 @@ public class WLGitBridgeIntegrationTest {
         File config = folder.newFile();
         PrintWriter writer = new PrintWriter(config);
         writer.println("{\n" +
-                "\t\"port\": " + port + ",\n" +
-                "\t\"rootGitDirectory\": \"" + wlgb.getAbsolutePath() + "\",\n" +
-                "\t\"apiBaseUrl\": \"http://127.0.0.1:" + apiPort + "/api/v0\",\n" +
-                "\t\"username\": \"\",\n" +
-                "\t\"password\": \"\",\n" +
-                "\t\"postbackBaseUrl\": \"http://127.0.0.1:" + port + "\",\n" +
-                "\t\"serviceName\": \"Overleaf\"\n," +
-                "    \"oauth2\": {\n" +
-                "        \"oauth2ClientID\": \"clientID\",\n" +
-                "        \"oauth2ClientSecret\": \"oauth2 client secret\",\n" +
-                "        \"oauth2Server\": \"https://www.overleaf.com\"\n" +
-                "    }\n" +
-                "}\n");
+            "\t\"port\": " + port + ",\n" +
+            "\t\"rootGitDirectory\": \"" + wlgb.getAbsolutePath() + "\",\n" +
+            "\t\"apiBaseUrl\": \"http://127.0.0.1:" + apiPort + "/api/v0\",\n" +
+            "\t\"username\": \"\",\n" +
+            "\t\"password\": \"\",\n" +
+            "\t\"postbackBaseUrl\": \"http://127.0.0.1:" + port + "\",\n" +
+            "\t\"serviceName\": \"Overleaf\"\n," +
+            "    \"oauth2\": {\n" +
+            "        \"oauth2ClientID\": \"clientID\",\n" +
+            "        \"oauth2ClientSecret\": \"oauth2 client secret\",\n" +
+            "        \"oauth2Server\": \"https://www.overleaf.com\"\n" +
+            "    }\n" +
+            "}\n");
         writer.close();
         return config.getAbsolutePath();
     }


### PR DESCRIPTION
The test don't pass unless a minimal configuration for Git is provided. With this change, we don't rely on the final user to provide this configuration.

Every time a repository is cloned on tests we're adding a configuration only for that repository that's not going to clash with any other configuration already set.

I've also included a commit with indentation fixes, so probably is better to review this 
