### PR TITLE
Build RepositoryObjectTreeWalker only once per commit

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/data/model/DataStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/model/DataStore.java
@@ -12,6 +12,7 @@ import uk.ac.ic.wlgitbridge.data.filestore.RawDirectory;
 import uk.ac.ic.wlgitbridge.data.filestore.RawFile;
 import uk.ac.ic.wlgitbridge.data.model.db.PersistentStore;
 import uk.ac.ic.wlgitbridge.data.model.db.SqlitePersistentStore;
+import uk.ac.ic.wlgitbridge.git.util.RepositoryObjectTreeWalker;
 import uk.ac.ic.wlgitbridge.snapshot.base.ForbiddenException;
 import uk.ac.ic.wlgitbridge.snapshot.getforversion.SnapshotAttachment;
 import uk.ac.ic.wlgitbridge.snapshot.push.exception.SnapshotPostException;
@@ -75,6 +76,7 @@ public class DataStore {
                                           List<Snapshot> snapshots)
             throws IOException, GitAPIException, SnapshotPostException {
         for (Snapshot snapshot : snapshots) {
+            Map<String, RawFile> fileTable = new RepositoryObjectTreeWalker(repository).getDirectoryContents().getFileTable();
             List<RawFile> files = new LinkedList<RawFile>();
             files.addAll(snapshot.getSrcs());
             Map<String, byte[]> fetchedUrls = new HashMap<String, byte[]>();
@@ -84,7 +86,7 @@ public class DataStore {
                                 name,
                                 snapshotAttachment.getUrl(),
                                 snapshotAttachment.getPath(),
-                                repository,
+                                fileTable,
                                 fetchedUrls
                         )
                 );

--- a/src/main/java/uk/ac/ic/wlgitbridge/data/model/ResourceFetcher.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/model/ResourceFetcher.java
@@ -29,7 +29,7 @@ public class ResourceFetcher {
         this.persistentStore = persistentStore;
     }
 
-    public RawFile get(String projectName, String url, String newPath, Repository repository, Map<String, byte[]> fetchedUrls) throws IOException, SnapshotPostException {
+    public RawFile get(String projectName, String url, String newPath, Map<String, RawFile> fileTable, Map<String, byte[]> fetchedUrls) throws IOException, SnapshotPostException {
         String path = persistentStore.getPathForURLInProject(projectName, url);
         byte[] contents;
         if (path == null) {
@@ -41,7 +41,7 @@ public class ResourceFetcher {
             Log.info("At (" + projectName + "): " + path);
             contents = fetchedUrls.get(url);
             if (contents == null) {
-                RawFile rawFile = new RepositoryObjectTreeWalker(repository).getDirectoryContents().getFileTable().get(path);
+                RawFile rawFile = fileTable.get(path);
                 if (rawFile == null) {
                     Log.warn(
                         "File " + path + " was not in the current commit, or the git tree, yet path was not null. " +

--- a/src/test/java/uk/ac/ic/wlgitbridge/data/model/ResourceFetcherTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/data/model/ResourceFetcherTest.java
@@ -9,7 +9,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.junit.MockServerRule;
+import uk.ac.ic.wlgitbridge.data.filestore.RawFile;
 import uk.ac.ic.wlgitbridge.data.model.db.PersistentStore;
+import uk.ac.ic.wlgitbridge.git.util.RepositoryObjectTreeWalker;
 import uk.ac.ic.wlgitbridge.snapshot.push.exception.SnapshotPostException;
 
 import java.io.IOException;
@@ -62,8 +64,9 @@ public class ResourceFetcherTest {
         TemporaryFolder repositoryFolder = new TemporaryFolder();
         repositoryFolder.create();
         Repository repository = new FileRepositoryBuilder().setWorkTree(repositoryFolder.getRoot()).build();
+        Map<String, RawFile> fileTable = new RepositoryObjectTreeWalker(repository).getDirectoryContents().getFileTable();
         Map<String, byte[]> fetchedUrls = new HashMap<String, byte[]>();
-        resourceFetcher.get(testProjectName, testUrl, newTestPath, repository, fetchedUrls);
+        resourceFetcher.get(testProjectName, testUrl, newTestPath, fileTable, fetchedUrls);
 
         // We don't bother caching in this case, at present.
         assertEquals(0, fetchedUrls.size());


### PR DESCRIPTION
We're building a RepositoryObjectTreeWalker object on each attachment and this probably is causing some performance issues.
