### PR TITLE
Improved disk space calculation and increased postback timeout

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStore.java
@@ -12,6 +12,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 
 import static uk.ac.ic.wlgitbridge.util.Util.deleteInDirectoryApartFrom;
 
@@ -22,10 +23,16 @@ public class FSGitRepoStore implements RepoStore {
 
     private final String repoStorePath;
     private final File rootDirectory;
+    private final Function<File, Long> fsSizer;
 
     public FSGitRepoStore(String repoStorePath) {
+        this(repoStorePath, d -> d.getTotalSpace() - d.getFreeSpace());
+    }
+
+    public FSGitRepoStore(String repoStorePath, Function<File, Long> fsSizer) {
         this.repoStorePath = repoStorePath;
         rootDirectory = initRootGitDirectory(repoStorePath);
+        this.fsSizer = fsSizer;
     }
 
     @Override
@@ -54,7 +61,7 @@ public class FSGitRepoStore implements RepoStore {
 
     @Override
     public long totalSize() {
-        return FileUtils.sizeOfDirectory(rootDirectory);
+        return fsSizer.apply(rootDirectory);
     }
 
     @Override

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/push/PostbackPromise.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/push/PostbackPromise.java
@@ -35,7 +35,7 @@ public class PostbackPromise {
         try {
             while (!received) {
                 try {
-                    if (!cond.await(30, TimeUnit.SECONDS)) {
+                    if (!cond.await(60, TimeUnit.SECONDS)) {
                         throw new PostbackTimeoutException();
                     }
                 } catch (InterruptedException e) {

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/push/exception/PostbackTimeoutException.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/push/exception/PostbackTimeoutException.java
@@ -13,7 +13,7 @@ public class PostbackTimeoutException extends SevereSnapshotPostException {
 
     @Override
     public String getMessage() {
-        return "timeout";
+        return "timeout (60s)";
     }
 
     @Override

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStoreTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStoreTest.java
@@ -1,20 +1,17 @@
 package uk.ac.ic.wlgitbridge.bridge.repo;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import uk.ac.ic.wlgitbridge.util.Files;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * Created by winston on 23/08/2016.
@@ -52,16 +49,29 @@ public class FSGitRepoStoreTest {
     public void testPurgeNonexistentProjects() {
         File toDelete = new File(repoStore.getRootDirectory(), "idontexist");
         File wlgb = new File(repoStore.getRootDirectory(), ".wlgb");
-        Assert.assertTrue(toDelete.exists());
-        Assert.assertTrue(wlgb.exists());
+        assertTrue(toDelete.exists());
+        assertTrue(wlgb.exists());
         repoStore.purgeNonexistentProjects(Arrays.asList("proj1", "proj2"));
-        Assert.assertFalse(toDelete.exists());
-        Assert.assertTrue(wlgb.exists());
+        assertFalse(toDelete.exists());
+        assertTrue(wlgb.exists());
     }
 
     @Test
-    public void testTotalSize() {
-        assertEquals(31860, repoStore.totalSize());
+    public void totalSizeShouldChangeWhenFilesAreCreatedAndDeleted()
+            throws IOException {
+        long old = repoStore.totalSize();
+        repoStore.remove("proj1");
+        long new_ = repoStore.totalSize();
+        assertTrue(new_ < old);
+        try (
+                OutputStream out = new FileOutputStream(
+                        new File(repoStore.getRootDirectory(), "__temp.txt")
+                )
+        ) {
+            out.write(new byte[1 * 1024 * 1024]);
+        }
+        long new__ = repoStore.totalSize();
+        assertTrue(new__ > new_);
     }
 
     @Test
@@ -69,10 +79,10 @@ public class FSGitRepoStoreTest {
         long beforeSize = repoStore.totalSize();
         InputStream zipped = repoStore.bzip2Project("proj1");
         repoStore.remove("proj1");
-        Assert.assertTrue(beforeSize > repoStore.totalSize());
+        assertTrue(beforeSize > repoStore.totalSize());
         repoStore.unbzip2Project("proj1", zipped);
-        Assert.assertEquals(beforeSize, repoStore.totalSize());
-        Assert.assertTrue(
+        assertEquals(beforeSize, repoStore.totalSize());
+        assertTrue(
                 Files.contentsAreEqual(
                         original,
                         repoStore.getRootDirectory()

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStoreTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStoreTest.java
@@ -60,18 +60,19 @@ public class FSGitRepoStoreTest {
     public void totalSizeShouldChangeWhenFilesAreCreatedAndDeleted()
             throws IOException {
         long old = repoStore.totalSize();
-        repoStore.remove("proj1");
-        long new_ = repoStore.totalSize();
-        assertTrue(new_ < old);
+        File temp = new File(repoStore.getRootDirectory(), "__temp.txt");
         try (
                 OutputStream out = new FileOutputStream(
-                        new File(repoStore.getRootDirectory(), "__temp.txt")
+                        temp
                 )
         ) {
-            out.write(new byte[1 * 1024 * 1024]);
+            out.write(new byte[16 * 1024 * 1024]);
         }
+        long new_ = repoStore.totalSize();
+        assertTrue(new_ > old);
+        assertTrue(temp.delete());
         long new__ = repoStore.totalSize();
-        assertTrue(new__ > new_);
+        assertTrue(new__ < new_);
     }
 
     @Test

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImplTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImplTest.java
@@ -1,5 +1,6 @@
 package uk.ac.ic.wlgitbridge.bridge.swap.job;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -43,7 +44,8 @@ public class SwapJobImplTest {
                 FSGitRepoStoreTest.makeTempRepoDir(
                         tmpFolder,
                         "repostore"
-                ).getAbsolutePath()
+                ).getAbsolutePath(),
+                FileUtils::sizeOfDirectory
         );
         dbStore = new SqliteDBStore(tmpFolder.newFile());
         dbStore.setLatestVersionForProject("proj1", 0);


### PR DESCRIPTION
- The postback timeout has been increased to 60s.
- `FSGitRepoStore` uses a `df` equivalent for `.totalSize()`.

I decided not to mock `FSGitRepoStore.totalSize()` because it's bad practice to use partial mocks for code that you own. Instead, we have the option of giving it a strategy for calculating total size.

It defaults to using the equivalent of `df`, whose basic behaviour is tested in `FSGitRepoStoreTest.totalSizeShouldChangeWhenFilesAreCreatedAndDeleted()`. I used a relatively large file (16 Mi) in case of random stuff happening in the os (which we can't really prevent).

In other tests, we use the old `FileUtils.sizeOfDirectory()` so that our results are deterministic.
