### PR TITLE
Simple Error Page to Replace Default

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -123,6 +123,9 @@ public class GitBridgeServer {
         handlers.addHandler(new DefaultHandler());
 
         api.setHandler(handlers);
+
+        ProductionErrorHandler errorHandler = new ProductionErrorHandler();
+        api.setErrorHandler(errorHandler);
         return api;
     }
 
@@ -149,6 +152,8 @@ public class GitBridgeServer {
                 ),
                 "/*"
         );
+        ProductionErrorHandler errorHandler = new ProductionErrorHandler();
+        servletContextHandler.setErrorHandler(errorHandler);
         return servletContextHandler;
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/ProductionErrorHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/ProductionErrorHandler.java
@@ -1,0 +1,21 @@
+package uk.ac.ic.wlgitbridge.server;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.handler.ErrorHandler;
+import java.io.IOException;
+
+public class ProductionErrorHandler extends ErrorHandler {
+    @Override
+    public void handle(
+    		String target, 
+    		org.eclipse.jetty.server.Request baseRequest, 
+    		HttpServletRequest request, 
+    		HttpServletResponse response
+    	) throws IOException {
+	        response.getWriter()
+	            .append("{\"message\":\"HTTP error ")
+	            .append(String.valueOf(response.getStatus()))
+	            .append("\"}");
+    	}
+}


### PR DESCRIPTION
To address #3619

We had two reports on HackerOne for security problems with using the default Jetty error pages. Quickly summarising:

- Exposes what tech we're using so someone could find a vulnerability based on googling Jetty + version number
- We repeat back whatever anyone puts in the requested url

These are summarised in more detail in [an issue on the main WL repo](https://github.com/overleaf/write_latex/issues/3619)

This instead returns a JSON string with the error code.

It would probably be good to make this configurable in the config file, but being new to this codebase I thought it would be good to plug the security holes rather than wait on me figuring out how to do that.