### PR TITLE
Empty file in dotgit: direct response to Git Bridge Fails to Clone With IllegalStateException (#3705)

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStore.java
@@ -76,13 +76,13 @@ public class FSGitRepoStore implements RepoStore {
             String projectName,
             long[] sizePtr
     ) throws IOException {
-        Preconditions.checkArgument(Project.isValidProjectName(projectName));
+        Project.checkValidProjectName(projectName);
         return Tar.bz2.zip(getDotGitForProject(projectName), sizePtr);
     }
 
     @Override
     public void remove(String projectName) throws IOException {
-        Preconditions.checkArgument(Project.isValidProjectName(projectName));
+        Project.checkValidProjectName(projectName);
         FileUtils.deleteDirectory(new File(rootDirectory, projectName));
     }
 
@@ -91,13 +91,22 @@ public class FSGitRepoStore implements RepoStore {
             String projectName,
             InputStream dataStream
     ) throws IOException {
-        Preconditions.checkArgument(Project.isValidProjectName(projectName));
-        Preconditions.checkState(getDirForProject(projectName).mkdirs());
+        Preconditions.checkArgument(
+                Project.isValidProjectName(projectName),
+                "[%s] invalid project name: ",
+                projectName
+        );
+        Preconditions.checkState(
+                getDirForProject(projectName).mkdirs(),
+                "[%s] directories for " +
+                        "evicted project already exist",
+                projectName
+        );
         Tar.bz2.unzip(dataStream, getDirForProject(projectName));
     }
 
     private File getDirForProject(String projectName) {
-        Preconditions.checkArgument(Project.isValidProjectName(projectName));
+        Project.checkValidProjectName(projectName);
         return Paths.get(
                 rootDirectory.getAbsolutePath()
         ).resolve(
@@ -106,7 +115,7 @@ public class FSGitRepoStore implements RepoStore {
     }
 
     private File getDotGitForProject(String projectName) {
-        Preconditions.checkArgument(Project.isValidProjectName(projectName));
+        Project.checkValidProjectName(projectName);
         return Paths.get(
                 rootDirectory.getAbsolutePath()
         ).resolve(
@@ -119,7 +128,12 @@ public class FSGitRepoStore implements RepoStore {
     private File initRootGitDirectory(String rootGitDirectoryPath) {
         File rootGitDirectory = new File(rootGitDirectoryPath);
         rootGitDirectory.mkdirs();
-        Preconditions.checkArgument(rootGitDirectory.isDirectory());
+        Preconditions.checkArgument(
+                rootGitDirectory.isDirectory(),
+                "given root git directory " +
+                        "is not a directory: %s",
+                rootGitDirectory.getAbsolutePath()
+        );
         return rootGitDirectory;
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImpl.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImpl.java
@@ -158,7 +158,7 @@ public class SwapJobImpl implements SwapJob {
      */
     @Override
     public void evict(String projName) throws IOException {
-        Preconditions.checkNotNull(projName);
+        Preconditions.checkNotNull(projName, "projName was null");
         Log.info("Evicting project: {}", projName);
         try (LockGuard __ = lock.lockGuard(projName)) {
             long[] sizePtr = new long[1];

--- a/src/main/java/uk/ac/ic/wlgitbridge/util/BiConsumerT.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/util/BiConsumerT.java
@@ -1,0 +1,11 @@
+package uk.ac.ic.wlgitbridge.util;
+
+/**
+ * BiConsumer interface that allows checked exceptions.
+ */
+@FunctionalInterface
+public interface BiConsumerT<T, U, E extends Throwable> {
+
+    void accept(T t, U u) throws E;
+
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/util/FunctionT.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/util/FunctionT.java
@@ -1,0 +1,14 @@
+package uk.ac.ic.wlgitbridge.util;
+
+/**
+ * Function interface that allows checked exceptions.
+ * @param <T>
+ * @param <R>
+ * @param <E>
+ */
+@FunctionalInterface
+public interface FunctionT<T, R, E extends Throwable> {
+
+    R apply(T t) throws E;
+
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/util/Project.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/util/Project.java
@@ -1,5 +1,7 @@
 package uk.ac.ic.wlgitbridge.util;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Created by winston on 23/08/2016.
  */
@@ -8,6 +10,11 @@ public class Project {
     public static boolean isValidProjectName(String projectName) {
         return projectName != null && !projectName.isEmpty()
                 && !projectName.startsWith(".");
+    }
+
+    public static void checkValidProjectName(String projectName) {
+        Preconditions.checkArgument(isValidProjectName(projectName),
+                "[%s] invalid project name", projectName);
     }
 
 }

--- a/src/main/java/uk/ac/ic/wlgitbridge/util/ResourceUtil.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/util/ResourceUtil.java
@@ -1,0 +1,32 @@
+package uk.ac.ic.wlgitbridge.util;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ResourceUtil {
+
+    /**
+     * Creates a copy of a resource folder. Mainly used for testing to prevent
+     * the original folder from being mangled.
+     *
+     * It will have the same name as the original.
+     * @param resource the resource name, e.g. "/uk/ac/ic/wlgitbridge/file.txt"
+     * @param folderProvider function used to create the folder.
+     *                       E.g. TemporaryFolder from junit
+     * @return
+     * @throws IOException
+     */
+    public static File copyOfFolderResource(
+            String resource,
+            FunctionT<String, File, IOException> folderProvider
+    ) throws IOException {
+        File original
+                = new File(ResourceUtil.class.getResource(resource).getFile());
+        File tmp = folderProvider.apply(original.getName());
+        FileUtils.copyDirectory(original, tmp);
+        return tmp;
+    }
+
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/util/Tar.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/util/Tar.java
@@ -101,8 +101,9 @@ public class Tar {
             }
             long size = e.getSize();
             Preconditions.checkArgument(
-                    size > 0 && size < Integer.MAX_VALUE,
-                    "file too big: tarTo should have thrown an IOException"
+                    size >= 0 && size <= Integer.MAX_VALUE,
+                    "file too big (" + size + " B): " +
+                            "tarTo should have thrown an IOException"
             );
             try (OutputStream out = new FileOutputStream(f)) {
                 /* TarInputStream pretends each


### PR DESCRIPTION
This is directly in response to overleaf/write_latex#3705.

- We test/fix a file size precondition check from `size > 0 && size < Integer.MAX_VALUE` to `size >= 0 && size <= Integer.MAX_VALUE`.

- Also some code quality changes.

It's easiest to go over each commit separately:

1. The code for the failing test
2. The actual fix, which is rather trivial
3. Code to make sure our precondition checks give a bit more info

1 and 3 are the bulk of the changes.

Tested on macOS 10.12.6 and Ubuntu 14.04.5 LTS.