### PR TITLE
#24 Part 2/6: file too big fix

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
@@ -67,7 +67,7 @@ import java.util.*;
  *    @see WLRepositoryResolver - used on all requests associate a repo with a
  *                                project name, or fail
  *
-*     @see WLUploadPackFactory - used to handle clones and fetches
+ *    @see WLUploadPackFactory - used to handle clones and fetches
  *
  *    @see WLReceivePackFactory - used to handle pushes by setting a hook
  *    @see WriteLatexPutHook - the hook used to handle pushes
@@ -315,7 +315,7 @@ public class Bridge {
             Credential oauth2,
             String projectName
     ) throws ServiceMayNotContinueException,
-             GitUserException {
+            GitUserException {
         Log.info("[{}] Checking that project exists", projectName);
         try (LockGuard __ = lock.lockGuard(projectName)) {
             GetDocRequest getDocRequest = new GetDocRequest(
@@ -511,13 +511,11 @@ public class Bridge {
                 projectName,
                 postbackKey
         );
-        try (
-                CandidateSnapshot candidate = createCandidateSnapshot(
-                                projectName,
-                                directoryContents,
-                                oldDirectoryContents
-                );
-        ) {
+        try (CandidateSnapshot candidate = createCandidateSnapshot(
+                projectName,
+                directoryContents,
+                oldDirectoryContents
+        )) {
             Log.info(
                     "[{}] Candindate snapshot created: {}",
                     projectName,
@@ -695,7 +693,7 @@ public class Bridge {
     ) throws IOException, GitUserException {
         String name = repo.getProjectName();
         for (Snapshot snapshot : snapshots) {
-            Map<String, RawFile> fileTable = repo.getFiles();
+            Map<String, RawFile> fileTable = repo.getFiles(50 * 1024 * 1024);
             List<RawFile> files = new LinkedList<>();
             files.addAll(snapshot.getSrcs());
             Map<String, byte[]> fetchedUrls = new HashMap<>();
@@ -785,3 +783,4 @@ public class Bridge {
     }
 
 }
+

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/GitProjectRepo.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/GitProjectRepo.java
@@ -55,9 +55,7 @@ public class GitProjectRepo implements ProjectRepo {
     }
 
     @Override
-    public void initRepo(
-            RepoStore repoStore
-    ) throws IOException {
+    public void initRepo(RepoStore repoStore) throws IOException {
         initRepositoryField(repoStore);
         Preconditions.checkState(repository.isPresent());
         Repository repo = this.repository.get();
@@ -66,9 +64,7 @@ public class GitProjectRepo implements ProjectRepo {
     }
 
     @Override
-    public void useExistingRepository(
-            RepoStore repoStore
-    ) throws IOException {
+    public void useExistingRepository(RepoStore repoStore) throws IOException {
         initRepositoryField(repoStore);
         Preconditions.checkState(repository.isPresent());
         Preconditions.checkState(
@@ -77,7 +73,7 @@ public class GitProjectRepo implements ProjectRepo {
     }
 
     @Override
-    public Map<String, RawFile> getFiles()
+    public Map<String, RawFile> getFiles(long maxFileSize)
             throws IOException, GitUserException {
         Preconditions.checkState(repository.isPresent());
         return new RepositoryObjectTreeWalker(
@@ -87,8 +83,7 @@ public class GitProjectRepo implements ProjectRepo {
 
     @Override
     public Collection<String> commitAndGetMissing(
-            GitDirectoryContents contents
-    ) throws IOException {
+            GitDirectoryContents contents) throws IOException {
         try {
             return doCommitAndGetMissing(contents);
         } catch (GitAPIException e) {
@@ -259,7 +254,8 @@ public class GitProjectRepo implements ProjectRepo {
                 name,
                 contents.getDirectory().getAbsolutePath()
         );
-        Util.deleteInDirectoryApartFrom(contents.getDirectory(), ".git");
+        Util.deleteInDirectoryApartFrom(
+                contents.getDirectory(), ".git");
         return missingFiles;
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/ProjectRepo.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/ProjectRepo.java
@@ -16,20 +16,14 @@ public interface ProjectRepo {
 
     String getProjectName();
 
-    void initRepo(
-            RepoStore repoStore
-    ) throws IOException;
+    void initRepo(RepoStore repoStore) throws IOException;
 
-    void useExistingRepository(
-            RepoStore repoStore
-    ) throws IOException;
+    void useExistingRepository(RepoStore repoStore) throws IOException;
 
-    Map<String, RawFile> getFiles(
-    ) throws IOException, GitUserException;
+    Map<String, RawFile> getFiles(long maxFileSize) throws IOException, GitUserException;
 
     Collection<String> commitAndGetMissing(
-            GitDirectoryContents gitDirectoryContents
-    ) throws IOException;
+            GitDirectoryContents gitDirectoryContents) throws IOException;
 
     void runGC() throws IOException;
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/util/CastUtil.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/util/CastUtil.java
@@ -1,0 +1,18 @@
+package uk.ac.ic.wlgitbridge.bridge.util;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Created by winston on 01/07/2017.
+ */
+public class CastUtil {
+
+    public static int assumeInt(long l) {
+        Preconditions.checkArgument(
+                l <= (long) Integer.MAX_VALUE
+                        && l >= (long) Integer.MIN_VALUE,
+                l + " cannot fit inside an int");
+        return (int) l;
+    }
+
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/data/filestore/RepositoryFile.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/filestore/RepositoryFile.java
@@ -1,7 +1,5 @@
 package uk.ac.ic.wlgitbridge.data.filestore;
 
-import java.util.Map.Entry;
-
 /**
  * Created by Winston on 16/11/14.
  */
@@ -9,11 +7,6 @@ public class RepositoryFile extends RawFile {
 
     private final String path;
     private final byte[] contents;
-
-    public RepositoryFile(Entry<String, byte[]> fileContents) {
-        path = fileContents.getKey();
-        contents = fileContents.getValue();
-    }
 
     public RepositoryFile(String path, byte[] contents) {
         this.path = path;

--- a/src/main/java/uk/ac/ic/wlgitbridge/git/exception/SizeLimitExceededException.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/git/exception/SizeLimitExceededException.java
@@ -4,14 +4,21 @@ import uk.ac.ic.wlgitbridge.util.Util;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class SizeLimitExceededException extends GitUserException {
 
-    private final String path;
+    private final Optional<String> path;
 
-    public SizeLimitExceededException(String path) {
-        super();
+    private final long actualSize;
+
+    private final long maxSize;
+
+    public SizeLimitExceededException(
+            Optional<String> path, long actualSize, long maxSize) {
         this.path = path;
+        this.actualSize = actualSize;
+        this.maxSize = maxSize;
     }
 
     @Override
@@ -22,7 +29,7 @@ public class SizeLimitExceededException extends GitUserException {
     @Override
     public List<String> getDescriptionLines() {
         String filename =
-                path != null ? "File '" + path + "' is" : "There's a file";
+                path.isPresent() ? "File '" + path + "' is" : "There's a file";
         return Arrays.asList(
                 filename + " too large to push to "
                         + Util.getServiceName() + " via git",

--- a/src/main/java/uk/ac/ic/wlgitbridge/git/exception/SizeLimitExceededException.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/git/exception/SizeLimitExceededException.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public class SizeLimitExceededException extends GitUserException {
 
-    private static String path = null;
+    private final String path;
 
     public SizeLimitExceededException(String path) {
         super();

--- a/src/main/java/uk/ac/ic/wlgitbridge/git/handler/hook/WriteLatexPutHook.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/git/handler/hook/WriteLatexPutHook.java
@@ -15,7 +15,6 @@ import uk.ac.ic.wlgitbridge.git.handler.hook.exception.WrongBranchException;
 import uk.ac.ic.wlgitbridge.git.util.RepositoryObjectTreeWalker;
 import uk.ac.ic.wlgitbridge.snapshot.push.exception.InternalErrorException;
 import uk.ac.ic.wlgitbridge.snapshot.push.exception.OutOfDateException;
-import uk.ac.ic.wlgitbridge.snapshot.push.exception.SnapshotPostException;
 import uk.ac.ic.wlgitbridge.util.Log;
 
 import java.io.IOException;

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -44,9 +44,7 @@ public class GitBridgeServer {
     private String rootGitDirectoryPath;
     private String apiBaseURL;
 
-    public GitBridgeServer(
-            Config config
-    ) throws ServletException {
+    public GitBridgeServer(Config config) throws ServletException {
         org.eclipse.jetty.util.log.Log.setLog(new NullLogger());
         this.port = config.getPort();
         this.rootGitDirectoryPath = config.getRootGitDirectory();
@@ -84,7 +82,8 @@ public class GitBridgeServer {
             bridge.checkDB();
             jettyServer.start();
             bridge.startBackgroundJobs();
-            Log.info(Util.getServiceName() + "-Git Bridge server started");
+            Log.info(
+                    Util.getServiceName() + "-Git Bridge server started");
             Log.info("Listening on port: " + port);
             Log.info("Bridged to: " + apiBaseURL);
             Log.info("Postback base URL: " + Util.getPostbackURL());
@@ -104,9 +103,7 @@ public class GitBridgeServer {
         }
     }
 
-    private void configureJettyServer(
-            Config config
-    ) throws ServletException {
+    private void configureJettyServer(Config config) throws ServletException {
         HandlerCollection handlers = new HandlerList();
         handlers.addHandler(initApiHandler());
         handlers.addHandler(initGitHandler(config));
@@ -129,9 +126,7 @@ public class GitBridgeServer {
         return api;
     }
 
-    private Handler initGitHandler(
-            Config config
-    ) throws ServletException {
+    private Handler initGitHandler(Config config) throws ServletException {
         final ServletContextHandler servletContextHandler =
                 new ServletContextHandler(ServletContextHandler.SESSIONS);
         if (config.isUsingOauth2()) {
@@ -159,9 +154,8 @@ public class GitBridgeServer {
 
     private Handler initResourceHandler() {
         ResourceHandler resourceHandler = new FileHandler(bridge);
-        resourceHandler.setResourceBase(
-                new File(rootGitDirectoryPath, ".wlgb/atts").getAbsolutePath()
-        );
+        resourceHandler.setResourceBase(new File(
+                rootGitDirectoryPath, ".wlgb/atts").getAbsolutePath());
         return resourceHandler;
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/Oauth2Filter.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/Oauth2Filter.java
@@ -71,7 +71,7 @@ public class Oauth2Filter implements Filter {
             );
             return;
         }
-        Log.info("[{}] Auth not needed");
+        Log.info("[{}] Auth not needed", project);
         filterChain.doFilter(servletRequest, servletResponse);
     }
 

--- a/src/test/java/uk/ac/ic/wlgitbridge/data/model/ResourceFetcherTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/data/model/ResourceFetcherTest.java
@@ -28,15 +28,18 @@ import static org.mockserver.model.HttpResponse.response;
  * Created by m on 20/11/15.
  */
 public class ResourceFetcherTest {
+
     @Rule
     public MockServerRule mockServerRule = new MockServerRule(this);
 
     private MockServerClient mockServerClient;
 
     @Test
-    public void fetchesFilesThatAreMissingFromUrlStoreCache() throws IOException, GitUserException {
+    public void fetchesFilesThatAreMissingFromUrlStoreCache()
+            throws IOException, GitUserException {
         final String testProjectName = "123abc";
-        final String testUrl = "http://localhost:" + mockServerRule.getPort() + "/123abc";
+        final String testUrl = "http://localhost:"
+                + mockServerRule.getPort() + "/123abc";
         final String oldTestPath = "testPath";
         final String newTestPath = "missingPath";
 
@@ -58,19 +61,28 @@ public class ResourceFetcherTest {
             oneOf(dbStore).getPathForURLInProject(testProjectName, testUrl);
             will(returnValue(oldTestPath));
 
-            // It should update the URL index store once it has fetched; at present, it does not actually change the stored path.
-            oneOf(dbStore).addURLIndexForProject(testProjectName, testUrl, oldTestPath);
+            // It should update the URL index store once it has fetched;
+            // at present, it does not actually change the stored path.
+            oneOf(dbStore).addURLIndexForProject(
+                    testProjectName, testUrl, oldTestPath);
         }});
 
         ResourceCache resources = new UrlResourceCache(dbStore);
         TemporaryFolder repositoryFolder = new TemporaryFolder();
         repositoryFolder.create();
-        Repository repository = new FileRepositoryBuilder().setWorkTree(repositoryFolder.getRoot()).build();
-        Map<String, RawFile> fileTable = new RepositoryObjectTreeWalker(repository).getDirectoryContents().getFileTable();
-        Map<String, byte[]> fetchedUrls = new HashMap<String, byte[]>();
-        resources.get(testProjectName, testUrl, newTestPath, fileTable, fetchedUrls);
+        Repository repository = new FileRepositoryBuilder()
+                .setWorkTree(repositoryFolder.getRoot())
+                .build();
+        Map<String, RawFile> fileTable
+                = new RepositoryObjectTreeWalker(repository)
+                        .getDirectoryContents()
+                        .getFileTable();
+        Map<String, byte[]> fetchedUrls = new HashMap<>();
+        resources.get(
+                testProjectName, testUrl, newTestPath, fileTable, fetchedUrls);
 
         // We don't bother caching in this case, at present.
         assertEquals(0, fetchedUrls.size());
     }
+
 }


### PR DESCRIPTION
Splitting up #24 into multiple PRs.

This is the minimum change that fixes the file too big problem, using a hardcoded value instead of a config option.

There is also a bunch of random code cleanup.