### PR TITLE
Small code improvements around temporary files

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/util/DeletingFileInputStream.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/util/DeletingFileInputStream.java
@@ -38,4 +38,23 @@ public class DeletingFileInputStream extends FileInputStream {
             }
         }
     }
+
+    /**
+     * We shouldn't rely on this for correctness!
+     */
+    @Override
+    protected void finalize() throws IOException {
+        try {
+            super.finalize();
+        } finally {
+            if(file != null) {
+                Log.warn("File open at finalization time: {}", file.getCanonicalPath());
+                try {
+                    close();
+                } catch (IOException e) {
+                    Log.error("Failed to delete file", e);
+                }
+            }
+        }
+    }
 }

--- a/src/main/java/uk/ac/ic/wlgitbridge/util/Tar.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/util/Tar.java
@@ -68,7 +68,7 @@ public class Tar {
         tmp.deleteOnExit();
         try (FileOutputStream target = new FileOutputStream(tmp)) {
             tarTo(fileOrDir, target);
-            return new FileInputStream(tmp);
+            return new DeletingFileInputStream(tmp);
         }
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/util/Tar.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/util/Tar.java
@@ -42,6 +42,9 @@ public class Tar {
             /* Closes target */
             try (OutputStream bzip2 = new BZip2CompressorOutputStream(target)) {
                 tarTo(fileOrDir, bzip2);
+            } catch (IOException e) {
+                tmp.delete();
+                throw e;
             }
             if (sizePtr != null) {
                 sizePtr[0] = tmp.length();
@@ -69,6 +72,9 @@ public class Tar {
         try (FileOutputStream target = new FileOutputStream(tmp)) {
             tarTo(fileOrDir, target);
             return new DeletingFileInputStream(tmp);
+        } catch (IOException e) {
+            tmp.delete();
+            throw e;
         }
     }
 


### PR DESCRIPTION
While tracking down a temporary file leak, I didn't find any problems.  A much more plausible explanation is that we're simply not waiting long enough when shutting the process down, as it does need to delete files rather quickly in our current configuration.

That said, there are a couple of small fixes.

* There *is* a leak of temporary `.tar` (not `.tar.bz2`) files.  But I think those are only used in the tests, so it's not a big deal.
* There might be a subtle bug I've missed.  To see if that's the case I've added a finalizer to log garbage collected files which haven't been cleaned up.

Connects to https://github.com/overleaf/write_latex/issues/4457