### PR TITLE
Queue a garbage collection job after pushing to a repo

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
@@ -419,6 +419,8 @@ public class Bridge {
             Log.warn("[{}] IOException on put", projectName);
             throw e;
         }
+
+        gcJob.queueForGc(projectName);
     }
 
     /**

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/gc/GcJobImplTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/gc/GcJobImplTest.java
@@ -1,5 +1,7 @@
 package uk.ac.ic.wlgitbridge.bridge.gc;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.stubbing.OngoingStubbing;
 import uk.ac.ic.wlgitbridge.bridge.lock.LockGuard;
@@ -24,9 +26,20 @@ public class GcJobImplTest {
 
     RepoStore repoStore = mock(RepoStore.class);
 
-    ProjectLock locks = new ProjectLockImpl();
+    ProjectLock locks;
 
-    GcJobImpl gcJob = new GcJobImpl(repoStore, locks, 5);
+    GcJobImpl gcJob;
+
+    @Before
+    public void setup() {
+        locks = new ProjectLockImpl();
+        gcJob = new GcJobImpl(repoStore, locks, 5);
+    }
+
+    @After
+    public void teardown() {
+        gcJob.stop();
+    }
 
     @Test
     public void addedProjectsAreAllEventuallyGcedOnce() throws Exception {

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImplTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImplTest.java
@@ -1,6 +1,7 @@
 package uk.ac.ic.wlgitbridge.bridge.swap.job;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -72,6 +73,13 @@ public class SwapJobImplTest {
                 dbStore,
                 swapStore
         );
+    }
+
+    @After
+    public void teardown() {
+        if(swapJob != null) {
+            swapJob.stop();
+        }
     }
 
     @Test


### PR DESCRIPTION
There is an hourly garbage-collection job, but currently nothing is ever enqueued.  This PR adds a project to the queue when pushed to.  The implementation uses a set, so even if a project is pushed to many times over the course of an hour, it is only garbage collected once.

Doesn't add any new tests, as this logic is actually already tested (it just wasn't used anywhere in the real code).

**Connects to:** https://github.com/overleaf/write_latex/issues/4482

---

Also does some somewhat-unrelated fixing of job leaks in the tests, which vastly reduces noise in the output.  I did those because I tried changing the `git gc` command to `git gc --auto`, which made tests fail, and the output was hopelessly difficult to read.