### PR TITLE
When user clone/pull/etc a project which doesn't exist, print a nice message

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/git/handler/WLRepositoryResolver.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/git/handler/WLRepositoryResolver.java
@@ -13,6 +13,7 @@ import uk.ac.ic.wlgitbridge.git.servlet.WLGitServlet;
 import uk.ac.ic.wlgitbridge.server.GitBridgeServer;
 import uk.ac.ic.wlgitbridge.server.Oauth2Filter;
 import uk.ac.ic.wlgitbridge.snapshot.base.ForbiddenException;
+import uk.ac.ic.wlgitbridge.snapshot.base.MissingRepositoryException;
 import uk.ac.ic.wlgitbridge.util.Log;
 import uk.ac.ic.wlgitbridge.util.Util;
 
@@ -97,6 +98,8 @@ public class WLRepositoryResolver
         } catch (ServiceNotEnabledException e) {
             cannot occur
             */
+        } catch (MissingRepositoryException e) {
+            throw new ServiceMayNotContinueException(String.join("\n", e.getDescriptionLines()), e);
         } catch (ServiceMayNotContinueException e) {
             /* Such as FailedConnectionException */
             throw e;

--- a/src/main/java/uk/ac/ic/wlgitbridge/git/handler/WLRepositoryResolver.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/git/handler/WLRepositoryResolver.java
@@ -13,7 +13,6 @@ import uk.ac.ic.wlgitbridge.git.servlet.WLGitServlet;
 import uk.ac.ic.wlgitbridge.server.GitBridgeServer;
 import uk.ac.ic.wlgitbridge.server.Oauth2Filter;
 import uk.ac.ic.wlgitbridge.snapshot.base.ForbiddenException;
-import uk.ac.ic.wlgitbridge.snapshot.base.MissingRepositoryException;
 import uk.ac.ic.wlgitbridge.util.Log;
 import uk.ac.ic.wlgitbridge.util.Util;
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/git/handler/WLRepositoryResolver.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/git/handler/WLRepositoryResolver.java
@@ -109,7 +109,10 @@ public class WLRepositoryResolver
         } catch (ForbiddenException e) {
             throw new ServiceNotAuthorizedException();
         } catch (GitUserException e) {
-            throw new ServiceMayNotContinueException(String.join("\n", e.getDescriptionLines()), e);
+            throw new ServiceMayNotContinueException(
+                e.getMessage() + "\n" +
+                    String.join("\n", e.getDescriptionLines()),
+                e);
         } catch (IOException e) {
             Log.warn(
                     "IOException when trying to open repo: " + projName,

--- a/src/main/java/uk/ac/ic/wlgitbridge/git/handler/WLRepositoryResolver.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/git/handler/WLRepositoryResolver.java
@@ -98,8 +98,6 @@ public class WLRepositoryResolver
         } catch (ServiceNotEnabledException e) {
             cannot occur
             */
-        } catch (MissingRepositoryException e) {
-            throw new ServiceMayNotContinueException(String.join("\n", e.getDescriptionLines()), e);
         } catch (ServiceMayNotContinueException e) {
             /* Such as FailedConnectionException */
             throw e;
@@ -112,7 +110,7 @@ public class WLRepositoryResolver
         } catch (ForbiddenException e) {
             throw new ServiceNotAuthorizedException();
         } catch (GitUserException e) {
-            throw new ServiceMayNotContinueException(e.getMessage(), e);
+            throw new ServiceMayNotContinueException(String.join("\n", e.getDescriptionLines()), e);
         } catch (IOException e) {
             Log.warn(
                     "IOException when trying to open repo: " + projName,

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
@@ -45,6 +45,8 @@ public class MissingRepositoryException extends SnapshotAPIException {
 
     private List<String> descriptionLines;
 
+    public MissingRepositoryException() { this.descriptionLines = GENERIC_REASON; }
+
     public MissingRepositoryException(List<String> descriptionLines) {
         this.descriptionLines = descriptionLines;
     }

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
@@ -10,42 +10,39 @@ import java.util.List;
 public class MissingRepositoryException extends SnapshotAPIException {
 
     public static final List<String> GENERIC_REASON = Arrays.asList(
-        "This Overleaf project currently has no git access.",
+        "This Overleaf project currently has no git access, either",
+        "because the project does not exist, or git access is not enabled for the project.",
         "",
-        "If this problem persists, please contact us."
+        "If this problem persists, please contact us at at support@overleaf.com"
     );
 
     static List<String> buildExportedToV2Message(String remoteUrl) {
         if (remoteUrl == null) {
             return Arrays.asList(
-                    "This Overleaf project has been moved to Overleaf v2 and cannot be used with git at this time.",
-                    "",
-                    "If this error persists, please contact us at support@overleaf.com, or",
-                    "see https://www.overleaf.com/help/342 for more information."
+                "This Overleaf project has been moved to Overleaf v2 and cannot be used with git at this time.",
+                "",
+                "If this error persists, please contact us at support@overleaf.com, or",
+                "see https://www.overleaf.com/help/342 for more information."
             );
         } else {
             return Arrays.asList(
-                    "This Overleaf project has been moved to Overleaf v2 and has a new identifier.",
-                    "Please update your remote to:",
-                    "",
-                    "    " + remoteUrl,
-                    "",
-                    "Assuming you are using the default \"origin\" remote, the following commands",
-                    "will change the remote for you:",
-                    "",
-                    "    git remote set-url origin " + remoteUrl,
-                    "",
-                    "If this does not work, please contact us at support@overleaf.com, or",
-                    "see https://www.overleaf.com/help/342 for more information."
+                "This Overleaf project has been moved to Overleaf v2 and has a new identifier.",
+                "Please update your remote to:",
+                "",
+                "    " + remoteUrl,
+                "",
+                "Assuming you are using the default \"origin\" remote, the following commands",
+                "will change the remote for you:",
+                "",
+                "    git remote set-url origin " + remoteUrl,
+                "",
+                "If this does not work, please contact us at support@overleaf.com, or",
+                "see https://www.overleaf.com/help/342 for more information."
             );
         }
     }
 
     private List<String> descriptionLines;
-
-    public MissingRepositoryException() {
-        descriptionLines = new ArrayList<String>();
-    }
 
     public MissingRepositoryException(List<String> descriptionLines) {
         this.descriptionLines = descriptionLines;

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
@@ -10,8 +10,9 @@ import java.util.List;
 public class MissingRepositoryException extends SnapshotAPIException {
 
     public static final List<String> GENERIC_REASON = Arrays.asList(
-        "This Overleaf project currently has no git access, either",
-        "because the project does not exist, or because git access is not enabled for the project.",
+        "This Overleaf project currently has no git access, either because",
+        "the project does not exist, or because git access is not enabled",
+        "for the project.",
         "",
         "If this is unexpected, please contact us at support@overleaf.com, or",
         "see https://www.overleaf.com/help/342 for more information."

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
@@ -11,9 +11,10 @@ public class MissingRepositoryException extends SnapshotAPIException {
 
     public static final List<String> GENERIC_REASON = Arrays.asList(
         "This Overleaf project currently has no git access, either",
-        "because the project does not exist, or git access is not enabled for the project.",
+        "because the project does not exist, or because git access is not enabled for the project.",
         "",
-        "If this problem persists, please contact us at at support@overleaf.com"
+        "If this is unexpected, please contact us at support@overleaf.com, or",
+        "see https://www.overleaf.com/help/342 for more information."
     );
 
     static List<String> buildExportedToV2Message(String remoteUrl) {

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
@@ -97,7 +97,7 @@ public abstract class Request<T extends Result> {
                         // disregard any errors that arose while handling the JSON
                     }
 
-                    throw new MissingRepositoryException(MissingRepositoryException.GENERIC_REASON);
+                    throw new MissingRepositoryException();
                 } else if (sc >= 400 && sc < 500) {
                     throw new MissingRepositoryException(MissingRepositoryException.GENERIC_REASON);
                 }

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
@@ -97,7 +97,7 @@ public abstract class Request<T extends Result> {
                         // disregard any errors that arose while handling the JSON
                     }
 
-                    throw new MissingRepositoryException();
+                    throw new MissingRepositoryException(MissingRepositoryException.GENERIC_REASON);
                 } else if (sc >= 400 && sc < 500) {
                     throw new MissingRepositoryException(MissingRepositoryException.GENERIC_REASON);
                 }


### PR DESCRIPTION
The old behaviour was to just show an equivalent of a 500 error.
This way, we catch the 404 from the API, and print an appropriate message
to the user.

## Screenshots

End result (updated): 

![image](https://user-images.githubusercontent.com/1540054/49939223-201b9300-fed4-11e8-85bb-e13b739f9615.png)


Child of https://github.com/overleaf/sharelatex/issues/1311