### PR TITLE
Extend http request timeouts

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
@@ -164,7 +164,6 @@ public abstract class Request<T extends Result> {
     private void setTimeouts(HttpRequest request) {
         // timeouts are 20s by default
         int threeMinutesInMs = 1000 * 60 * 3;
-        request.setConnectTimeout(threeMinutesInMs);
         request.setReadTimeout(threeMinutesInMs);
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
@@ -130,6 +130,7 @@ public abstract class Request<T extends Result> {
             HttpRequest request = Instance.httpRequestFactory.buildGetRequest(
                     new GenericUrl(url)
             );
+            setTimeouts(request);
             request(request);
         } catch (IOException e) {
             e.printStackTrace();
@@ -157,6 +158,13 @@ public abstract class Request<T extends Result> {
     private void request(HttpRequest request) throws IOException {
         onBeforeRequest(request);
         future = request.executeAsync();
+    }
+
+    private void setTimeouts(HttpRequest request) {
+        // timeouts are 20s by default
+        int threeMinutesInMs = 1000 * 60 * 3;
+        request.setConnectTimeout(threeMinutesInMs);
+        request.setReadTimeout(threeMinutesInMs);
     }
 
 }

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
@@ -148,6 +148,7 @@ public abstract class Request<T extends Result> {
                             getPostBody().getBytes()
                     )
             );
+            setTimeouts(request);
             request(request);
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Specualtive fix for https://github.com/overleaf/sharelatex/issues/1364

The default timeouts for [HttpRequest](https://developers.google.com/api-client-library/java/google-http-java-client/reference/1.20.0/com/google/api/client/http/HttpRequest) are 20s for connection and 20s for read. Bump both to three minutes.

# Manual testing

- [x] Added an artificial lag to web-api responses, and a `git pull` still (eventually) completes