### PR TITLE
Handle when v1 is deprecated, print a message instead of an error

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
@@ -18,6 +18,13 @@ public class MissingRepositoryException extends SnapshotAPIException {
         "see https://www.overleaf.com/help/342 for more information."
     );
 
+    public static final List<String> OVERLEAF_V1_DEPRECATED_REASON = Arrays.asList(
+            "Overleaf v1 is deprecated, and you need to migrate this project to v2.",
+            "",
+            "If this is unexpected, please contact us at support@overleaf.com, or",
+            "see https://www.overleaf.com/help/342 for more information."
+    );
+
     static List<String> buildExportedToV2Message(String remoteUrl) {
         if (remoteUrl == null) {
             return Arrays.asList(

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/MissingRepositoryException.java
@@ -18,12 +18,36 @@ public class MissingRepositoryException extends SnapshotAPIException {
         "see https://www.overleaf.com/help/342 for more information."
     );
 
-    public static final List<String> OVERLEAF_V1_DEPRECATED_REASON = Arrays.asList(
-            "Overleaf v1 is deprecated, and you need to migrate this project to v2.",
-            "",
-            "If this is unexpected, please contact us at support@overleaf.com, or",
-            "see https://www.overleaf.com/help/342 for more information."
-    );
+    static List<String> buildDeprecatedMessage(String newUrl) {
+        if (newUrl == null) {
+            return Arrays.asList(
+                    "This project has not yet been moved into the new version of Overleaf. You will",
+                    "need to move it in order to continue working on it. Please visit this project",
+                    "online on www.overleaf.com to do this.",
+                    "",
+                    "After migrating this project to the new version of Overleaf, you will be",
+                    "prompted to update your git remote to the project's new identifier.",
+                    "",
+                    "If this is unexpected, please contact us at support@overleaf.com, or",
+                    "see https://www.overleaf.com/help/342 for more information."
+            );
+        } else {
+            return Arrays.asList(
+                "This project has not yet been moved into the new version of Overleaf. You will",
+                "need to move it in order to continue working on it. Please visit this project",
+                "online to do this:",
+                "",
+                "    " + newUrl,
+                "",
+                "After migrating this project to the new version of Overleaf, you will be",
+                "prompted to update your git remote to the project's new identifier.",
+                "",
+                "If this is unexpected, please contact us at support@overleaf.com, or",
+                "see https://www.overleaf.com/help/342 for more information."
+            );
+        }
+
+    }
 
     static List<String> buildExportedToV2Message(String remoteUrl) {
         if (remoteUrl == null) {

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
@@ -90,6 +90,10 @@ public abstract class Request<T extends Result> {
                             throw new MissingRepositoryException(
                                 MissingRepositoryException.buildExportedToV2Message(newRemote)
                             );
+                        } else if ("Overleaf v1 is Deprecated".equals(message)) {
+                            throw new MissingRepositoryException(
+                                    MissingRepositoryException.OVERLEAF_V1_DEPRECATED_REASON
+                            );
                         }
                     } catch (IllegalStateException
                             | ClassCastException

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
@@ -91,8 +91,14 @@ public abstract class Request<T extends Result> {
                                 MissingRepositoryException.buildExportedToV2Message(newRemote)
                             );
                         } else if ("Overleaf v1 is Deprecated".equals(message)) {
+                            String newUrl;
+                            if (json.has("newUrl")) {
+                                newUrl = json.get("newUrl").getAsString();
+                            } else {
+                                newUrl = null;
+                            }
                             throw new MissingRepositoryException(
-                                    MissingRepositoryException.OVERLEAF_V1_DEPRECATED_REASON
+                                    MissingRepositoryException.buildDeprecatedMessage(newUrl)
                             );
                         }
                     } catch (IllegalStateException


### PR DESCRIPTION
Partial fix for https://github.com/overleaf/sharelatex/issues/1401