### PR TITLE
Handle imported, and unchanged, projects

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/snapshot/SnapshotApiFacade.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/snapshot/SnapshotApiFacade.java
@@ -97,7 +97,7 @@ public class SnapshotApiFacade {
                 = api.getSavedVers(oauth2, projectName);
         GetDocResult latestDoc = SnapshotApi.getResult(getDoc);
         int latest = latestDoc.getVersionID();
-        if (latest > version) {
+        if (latest > version || (latest == 0 && version == 0)) {
             for (
                     SnapshotInfo snapshotInfo :
                     SnapshotApi.getResult(savedVers).getSavedVers()

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/snapshot/SnapshotApiFacade.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/snapshot/SnapshotApiFacade.java
@@ -97,6 +97,9 @@ public class SnapshotApiFacade {
                 = api.getSavedVers(oauth2, projectName);
         GetDocResult latestDoc = SnapshotApi.getResult(getDoc);
         int latest = latestDoc.getVersionID();
+        // Handle edge-case for projects with no changes, that were imported
+        // to v2. In which case both `latest` and `version` will be zero.
+        // See: https://github.com/overleaf/writelatex-git-bridge/pull/50
         if (latest > version || (latest == 0 && version == 0)) {
             for (
                     SnapshotInfo snapshotInfo :

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getdoc/GetDocResult.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getdoc/GetDocResult.java
@@ -98,7 +98,11 @@ public class GetDocResult extends Result {
             }
         } else {
             versionID = jsonObject.get("latestVerId").getAsInt();
-            createdAt = jsonObject.get("latestVerAt").getAsString();
+            if (jsonObject.has("latestVerAt")) {
+                createdAt = jsonObject.get("latestVerAt").getAsString();
+            } else {
+                createdAt = null;
+            }
             if (jsonObject.has("migratedFromId")) {
                 migratedFromID = jsonObject.get("migratedFromId").getAsString();
             } else {

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getdoc/GetDocResult.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/getdoc/GetDocResult.java
@@ -98,6 +98,9 @@ public class GetDocResult extends Result {
             }
         } else {
             versionID = jsonObject.get("latestVerId").getAsInt();
+            // Handle edge-case for projects with no changes, that were imported
+            // to v2. In which case `latestVerAt` will not be present.
+            // See: https://github.com/overleaf/writelatex-git-bridge/pull/50
             if (jsonObject.has("latestVerAt")) {
                 createdAt = jsonObject.get("latestVerAt").getAsString();
             } else {

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/servermock/state/SnapshotAPIStateBuilder.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/servermock/state/SnapshotAPIStateBuilder.java
@@ -83,7 +83,20 @@ public class SnapshotAPIStateBuilder {
             String projectName,
             JsonObject jsonGetDoc
     ) {
+        int versionID = jsonGetDoc.get("versionID").getAsInt();
+        String createdAt = null;
+        String email = null;
+        String name = null;
         String migratedFromId = null;
+        if (jsonGetDoc.has("createdAt")) {
+            createdAt = jsonGetDoc.get("createdAt").getAsString();
+        }
+        if (jsonGetDoc.has("email")) {
+            email = jsonGetDoc.get("email").getAsString();
+        }
+        if (jsonGetDoc.has("name")) {
+            name = jsonGetDoc.get("name").getAsString();
+        }
         if (jsonGetDoc.has("migratedFromId")) {
             migratedFromId = jsonGetDoc.get("migratedFromId").getAsString();
         }
@@ -91,10 +104,10 @@ public class SnapshotAPIStateBuilder {
                 projectName,
                 new GetDocResult(
                         jsonGetDoc.get("error"),
-                        jsonGetDoc.get("versionID").getAsInt(),
-                        jsonGetDoc.get("createdAt").getAsString(),
-                        jsonGetDoc.get("email").getAsString(),
-                        jsonGetDoc.get("name").getAsString(),
+                        versionID,
+                        createdAt,
+                        email,
+                        name,
                         migratedFromId
                 )
         );

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -123,6 +123,9 @@ public class WLGitBridgeIntegrationTest {
         put("skipMigrationWhenMigratedFromMissing", new HashMap<String, SnapshotAPIState>() {{
             put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/skipMigrationWhenMigratedFromMissing/state/state.json")).build());
         }});
+        put("canCloneAMigratedRepositoryWithoutChanges", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/canCloneAMigratedRepositoryWithoutChanges/state/state.json")).build());
+        }});
     }};
 
     @Rule
@@ -828,6 +831,22 @@ public class WLGitBridgeIntegrationTest {
         wlgb.stop();
 
         assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/skipMigrationWhenMigratedFromMissing/state/testproj2"), testprojDir2.toPath()));
+    }
+
+    @Test
+    public void canCloneAMigratedRepositoryWithoutChanges() throws IOException, GitAPIException, InterruptedException {
+        int gitBridgePort = 33883;
+        int mockServerPort = 3883;
+        MockSnapshotServer server = new MockSnapshotServer(mockServerPort, getResource("/canCloneAMigratedRepositoryWithoutChanges").toFile());
+        server.start();
+        server.setState(states.get("canCloneAMigratedRepositoryWithoutChanges").get("state"));
+        GitBridgeApp wlgb = new GitBridgeApp(new String[] {
+                makeConfigFile(gitBridgePort, mockServerPort)
+        });
+        wlgb.run();
+        File testprojDir = gitClone("testproj_no_change", gitBridgePort, dir);
+        wlgb.stop();
+        assertTrue(FileUtil.gitDirectoriesAreEqual(getResource("/canCloneAMigratedRepositoryWithoutChanges/state/testproj_no_change"), testprojDir.toPath()));
     }
 
     private String makeConfigFile(

--- a/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/canCloneAMigratedRepositoryWithoutChanges/state/state.json
+++ b/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/canCloneAMigratedRepositoryWithoutChanges/state/state.json
@@ -1,0 +1,29 @@
+[
+	{
+		"project": "testproj_no_change",
+		"getDoc": {
+			"versionID": 0,
+			"createdAt": "2014-11-30T18:40:58.123Z",
+			"email": "jdleesmiller+1@gmail.com",
+			"name": "John+1"
+		},
+		"getSavedVers": [],
+		"getForVers": [
+			{
+				"versionID": 0,
+				"srcs": [
+                    {
+                    	"content": "test content\n",
+                    	"path": "main.tex"
+                    }
+	            ],
+	            "atts": []
+	        }
+		],
+		"push": "success",
+		"postback": {
+			"type": "success",
+			"versionID": 1
+		}
+	}
+]

--- a/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/canCloneAMigratedRepositoryWithoutChanges/state/testproj_no_change/main.tex
+++ b/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/canCloneAMigratedRepositoryWithoutChanges/state/testproj_no_change/main.tex
@@ -1,0 +1,1 @@
+test content


### PR DESCRIPTION
Addresses https://github.com/overleaf/sharelatex/issues/1399

If a project is created in v1, left unchanged, then imported to v2, it will have no "changes", and will start with a version number of `0`. (we should evaluate if this is really the correct behaviour on project import)

This is a problem for git-bridge, as it would crash when trying to get the absent `lastestVerAt` property from the version info. Fixing that issue revealed that when `version == 0` the git-bridge elects to just not fetch any content from the API, leading to an empty repo.

This PR fixes both issues, so that at least the repo can be cloned, with content. This is desirable in the short-term, so folks can move their projects from v1 to v2 and have things just work without needing to contact support.

Example git-log output from one of these projects with this change:

```
shanek@sk-fed:~/t/g/5c35e72e3389fa0148d8d788|master✓
➤ git log
commit eda8a92b53d74203ed341a77d6513118fc29c4b2 (HEAD -> master, origin/master, origin/HEAD)
Author: Anonymous <anonymous@overleaf.com>
Date:   Wed Jan 9 12:21:41 2019 +0000

    Update on Overleaf.
```

The author is set to `anonymous@overleaf.com`, and the timestamp is set to now.
