### PR TITLE
Increase postback timeout to six minutes

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/push/PostbackPromise.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/push/PostbackPromise.java
@@ -14,7 +14,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class PostbackPromise {
 
-    private static int TIMEOUT_SECONDS = 60 * 3;
+    private static int TIMEOUT_SECONDS = 60 * 6;
 
     private final String postbackKey;
     private final ReentrantLock lock;


### PR DESCRIPTION
This is a speculative fix to help users pushing large payloads to git-bridge.