### PR TITLE
Sk upgrade jgit 5.2 redux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean:
 	mvn clean
 
 
-package:
+package: clean
 	mvn package
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,13 +100,13 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>4.10.0.201712302008-r</version>
+            <version>5.2.1.201812262042-r</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit.http.server -->
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit.http.server</artifactId>
-            <version>4.10.0.201712302008-r</version>
+            <version>5.2.1.201812262042-r</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc -->
         <dependency>

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/NoGitignoreIterator.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/NoGitignoreIterator.java
@@ -51,11 +51,6 @@ public class NoGitignoreIterator extends FileTreeIterator {
         super(root, fs, options, fileModeStrategy);
     }
 
-    @Deprecated
-    protected NoGitignoreIterator(WorkingTreeIterator p, File root, FS fs) {
-        super(p, root, fs);
-    }
-
     protected NoGitignoreIterator(FileTreeIterator p, File root, FS fs) {
         super(p, root, fs);
     }


### PR DESCRIPTION
( Follow on from a failed deploy of https://github.com/overleaf/writelatex-git-bridge/pull/52, 
we had an incompatibility that was obscured by build caching in local dev )

--------

Yup. Might help with some client issues folks have been having.
Closes https://github.com/overleaf/sharelatex/issues/1597

Part of our efforts to upgrade dependencies: https://github.com/overleaf/write_latex/issues/3485

Local testing performed:
- Builds correctly
  - And tests pass
- Server starts
- Clone a repo
- Push
- Pull