### PR TITLE
Reject v1 ids earlier in the pipeline

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/git/handler/WLRepositoryResolver.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/git/handler/WLRepositoryResolver.java
@@ -83,23 +83,6 @@ public class WLRepositoryResolver
              ServiceNotAuthorizedException,
              ServiceMayNotContinueException {
         Log.info("[{}] Request to open git repo", name);
-        // Reject v1 ids, the request will be rejected by v1 anyway
-        if (name.matches("^[0-9]+[bcdfghjklmnpqrstvwxyz]{6,12}$") && !name.matches("^[0-9a-f]{24}$")) {
-            Log.info("[{}] Request for v1 project, refusing", name);
-            throw new ServiceMayNotContinueException(
-                String.join("\n", Arrays.asList(
-                    "This project has not yet been moved into the new version",
-                    "of Overleaf. You will need to move it in order to continue working on it.",
-                    "Please visit this project online on www.overleaf.com to do this.",
-                    "",
-                    "You can find the new git remote url by selecting \"Git\" from",
-                    "the left sidebar in the project view.",
-                    "",
-                    "If this is unexpected, please contact us at support@overleaf.com, or",
-                    "see https://www.overleaf.com/help/342 for more information."
-                ))
-            );
-        }
         Optional<Credential> oauth2 = Optional.ofNullable(
                 (Credential) httpServletRequest.getAttribute(
                         Oauth2Filter.ATTRIBUTE_KEY));


### PR DESCRIPTION
Follow on from https://github.com/overleaf/writelatex-git-bridge/pull/53 (which didn't quite solve the problem). In that PR I didn't account for the initial OAuth handshake, which sends requests to v1, so we still have quite a few of these 404s still.

This PR moves the rejection logic to before the OAuth work, so we should have no requests sent to v1.

Closes https://github.com/overleaf/sharelatex/issues/1607

This reduces the amount of 404s that we'll see on the git-bridge apis in v1, (https://github.com/overleaf/sharelatex/issues/1432).
Seeing as the v1 api will refuse the request anyway, we might as well short-circuit the process early, in git-bridge.

Example output from git, while trying to clone from a v1 id:

```
$ git clone http://git-bridge:8000/13466612chqmhjfqjrnq
Cloning into '13466612chqmhjfqjrnq'...
remote: This project has not yet been moved into the new version
remote: of Overleaf. You will need to move it in order to continue working on it.
remote: Please visit this project online on www.overleaf.com to do this.
remote: 
remote: You can find the new git remote url by selecting "Git" from
remote: the left sidebar in the project view.
remote: 
remote: If this is unexpected, please contact us at support@overleaf.com, or
remote: see https://www.overleaf.com/help/342 for more information.
fatal: repository 'http://git-bridge:8000/13466612chqmhjfqjrnq/' not found
```
