### PR TITLE
[docker] use a base image that already contains maven and openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,5 @@
 # Dockerfile for git-bridge
 
+FROM maven:3-jdk-8
 
-FROM ubuntu:latest
-
-
-RUN apt-get update && \
-  apt-get install -y git make maven openjdk-8-jdk curl && \
-  update-alternatives --install /usr/bin/java java /usr/lib/jvm/java-8-openjdk-amd64/bin/java 100 && \
-  update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac 100 && \
-  update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/bin/java && \
-  update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
-
-
-RUN mkdir /app
 WORKDIR /app


### PR DESCRIPTION
This PR makes use of the official maven docker image. This follows the docker principle of sharing common layers.