### PR TITLE
[docker] build the git-bridge in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 !/lib
 !/src/main
 !/pom.xml
+!/LICENSE

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!/lib
+!/src/main
+!/pom.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@
 
 FROM maven:3-jdk-8
 
-RUN apt-get update && apt-get install -y make git curl
-
 WORKDIR /app
 
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,20 @@ RUN apt-get update && \
 
 RUN mkdir /app
 WORKDIR /app
+
+COPY . /app
+RUN mvn clean package \
+# The name of the created jar contains the current version tag.
+# Rename it to a static path that can be used for copying.
+&&  find /app/target \
+      -name 'writelatex-git-bridge*jar-with-dependencies.jar' \
+      -exec mv {} /git-bridge.jar \;
+
+FROM openjdk:8-jre
+
+USER www-data
+
+ENTRYPOINT ["java", "-jar", "/git-bridge.jar"]
+CMD ["/conf/runtime.json"]
+
+COPY --from=0 /git-bridge.jar /

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,12 @@ RUN mvn clean package \
 
 FROM openjdk:8-jre
 
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y \
+      git \
+ && rm -rf \
+      /var/lib/apt/lists/*
+
 USER www-data
 
 ENTRYPOINT ["java", "-jar", "/git-bridge.jar"]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,26 @@
-writelatex-git-bridge
-=====================
+# writelatex-git-bridge
 
-Required
---------
+## Docker
+
+The `Dockerfile` contains all the requirements for building and running the
+ writelatex-git-bridge.
+
+```bash
+# build the image
+docker build -t writelatex-git-bridge .
+
+# run it with the demo config
+docker run -v `pwd`/conf/local.json:/conf/runtime.json writelatex-git-bridge
+```
+
+## Native install
+
+### Required packages
+
   * `maven` (for building, running tests and packaging)
   * `jdk-8` (for compiling and running)
 
-Commands
---------
+### Commands
 
 To be run from the base directory:
 
@@ -20,8 +33,7 @@ To be run from the base directory:
 **Clean**:
 `mvn clean`
 
-Installation
-------------
+### Installation
 
 Install dependencies:
 
@@ -39,8 +51,7 @@ Run `mvn package` to build, test, and package it into a jar at `target/writelate
 
 Use `java -jar <path_to_jar> <path_to_config_file>` to run the server.
 
-Runtime Configuration
----------------------
+## Runtime Configuration
 
 The configuration file is in `.json` format.
 


### PR DESCRIPTION
This PR simplifies the build of the git-bridge by moving it into a docker pipeline.