### PR TITLE
GitBridge: Allow colons in passwords

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/server/Oauth2Filter.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/Oauth2Filter.java
@@ -131,7 +131,7 @@ public class Oauth2Filter implements Filter {
                                 Base64.decodeBase64(st.nextToken()),
                                 "UTF-8"
                         );
-                        String[] split = credentials.split(":");
+                        String[] split = credentials.split(":",2);
                         if (split.length == 2) {
                             String username = split[0];
                             String password = split[1];


### PR DESCRIPTION
Add a limit to credentials `split` call, to only split at the first colon. This ensures that if your password contains a colon, it doesn't create an extra field in the `credentials` array.

Fixes overleaf/issues#1393