### PR TITLE
Temporarily disable the gc-on-swap feature

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImpl.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImpl.java
@@ -162,7 +162,8 @@ public class SwapJobImpl implements SwapJob {
         Preconditions.checkNotNull(projName, "projName was null");
         Log.info("Evicting project: {}", projName);
         try (LockGuard __ = lock.lockGuard(projName)) {
-            repoStore.gcProject(projName);
+            // NOTE: removed temporarily, behaving badly in production
+            // repoStore.gcProject(projName);
             long[] sizePtr = new long[1];
             try (InputStream blob = repoStore.bzip2Project(projName, sizePtr)) {
                 swapStore.upload(projName, blob, sizePtr[0]);


### PR DESCRIPTION
Emergency patch to turn off bad behaviour in production.

This one project is spamming errors:

```
GitBridgeApp: [55e522fdbf123c03637d7cff] Exception while swapping, giving up
2019-05-21 08:36:01.917 WARN  [Timer-0] GitBridgeApp: error: refs/heads/master does not point to a valid object!
error: refs/heads/master does not point to a valid object!
error: refs/heads/master does not point to a valid object!
fatal: bad object HEAD
error: failed to run repack
```