### PR TITLE
Log and trap/ignore gc errors during swap

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImpl.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImpl.java
@@ -162,7 +162,11 @@ public class SwapJobImpl implements SwapJob {
         Preconditions.checkNotNull(projName, "projName was null");
         Log.info("Evicting project: {}", projName);
         try (LockGuard __ = lock.lockGuard(projName)) {
-            repoStore.gcProject(projName);
+            try {
+                repoStore.gcProject(projName);
+            } catch (Exception e) {
+                Log.error("[{}] Exception while running gc on project: {}", projName, e);
+            }
             long[] sizePtr = new long[1];
             try (InputStream blob = repoStore.bzip2Project(projName, sizePtr)) {
                 swapStore.upload(projName, blob, sizePtr[0]);


### PR DESCRIPTION
Emergency patch to stop disk from filling up with errors on bad projects.

Swap process fails on gc for some projects (example 5c8188f417738731b356ca92), common factor is that they have their own `.git` folder. We think this is corrupting the repo, and swap job is retrying infinitely.

The latter problem also needs to be fixed, but we can fix it at this level too, allowing the swap to proceed.
