### PR TITLE
Handle a 409 response with code=projectHasDotGit

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
@@ -11,6 +11,7 @@ import uk.ac.ic.wlgitbridge.util.Log;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.*;
 
 /**
@@ -73,9 +74,30 @@ public abstract class Request<T extends Result> {
             if (cause instanceof HttpResponseException) {
                 HttpResponseException httpCause = (HttpResponseException) cause;
                 int sc = httpCause.getStatusCode();
-                if (sc == HttpServletResponse.SC_UNAUTHORIZED || sc == HttpServletResponse.SC_FORBIDDEN) {
+                if (sc == HttpServletResponse.SC_UNAUTHORIZED || sc == HttpServletResponse.SC_FORBIDDEN) {  // 401, 403
                     throw new ForbiddenException();
-                } else if (sc == HttpServletResponse.SC_NOT_FOUND) {
+                } else if (sc == HttpServletResponse.SC_CONFLICT) {  // 409
+                    try {
+                        JsonObject json = Instance.gson.fromJson(httpCause.getContent(), JsonObject.class);
+                        String code = json.get("code").getAsString();
+                        if ("projectHasDotGit".equals(code)) {
+                            throw new MissingRepositoryException(Arrays.asList(
+                                    "This project contains a '.git' entity at the top level, indicating that it is",
+                                    "already a git repository. The Overleaf git-bridge cannot work with this project",
+                                    "due to a known problem with handling these '.git' folders.",
+                                    "",
+                                    "If this is unexpected, please contact us at support@overleaf.com, or",
+                                    "see https://www.overleaf.com/help/342 for more information."
+                            ));
+                        } else {
+                            throw new MissingRepositoryException(Arrays.asList("Conflict: 409"));
+                        }
+                    } catch (IllegalStateException
+                            | ClassCastException
+                            | NullPointerException _e) { // json parse errors
+                        throw new MissingRepositoryException(Arrays.asList("Conflict: 409"));
+                    }
+                } else if (sc == HttpServletResponse.SC_NOT_FOUND) {  // 404
                     try {
                         JsonObject json = Instance.gson.fromJson(httpCause.getContent(), JsonObject.class);
                         String message = json.get("message").getAsString();

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -129,6 +129,9 @@ public class WLGitBridgeIntegrationTest {
         put("rejectV1Repository", new HashMap<String, SnapshotAPIState>() {{
             put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/rejectV1Repository/state/state.json")).build());
         }});
+        put("cannotCloneAHasDotGitProject", new HashMap<String, SnapshotAPIState>() {{
+            put("state", new SnapshotAPIStateBuilder(getResourceAsStream("/cannotCloneAHasDotGitProject/state/state.json")).build());
+        }});
     }};
 
     @Rule
@@ -866,6 +869,24 @@ public class WLGitBridgeIntegrationTest {
         Process gitProcess = runtime.exec("git clone http://127.0.0.1:" + gitBridgePort + "/1234bbccddff.git", null, dir);
         wlgb.stop();
         assertNotEquals(0, gitProcess.waitFor());
+    }
+
+    @Test
+    public void cannotCloneAHasDotGitProject() throws IOException, GitAPIException, InterruptedException {
+        int gitBridgePort = 33885;
+        int mockServerPort = 3885;
+
+        MockSnapshotServer server = new MockSnapshotServer(mockServerPort, getResource("/cannotCloneAHasDotGitProject").toFile());
+        server.start();
+        server.setState(states.get("cannotCloneAHasDotGitProject").get("state"));
+        GitBridgeApp wlgb = new GitBridgeApp(new String[] {
+                makeConfigFile(gitBridgePort, mockServerPort)
+        });
+
+        wlgb.run();
+        Process gitProcess = runtime.exec("git clone http://127.0.0.1:" + gitBridgePort + "/conflict.git", null, dir);
+        assertNotEquals(0, gitProcess.waitFor());
+        wlgb.stop();
     }
 
     private String makeConfigFile(

--- a/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/cannotCloneAHasDotGitProject/state/state.json
+++ b/src/test/resources/uk/ac/ic/wlgitbridge/WLGitBridgeIntegrationTest/cannotCloneAHasDotGitProject/state/state.json
@@ -1,0 +1,19 @@
+[
+    {
+        "project": "conflict",
+        "getDoc": {
+            "error": 409,
+            "code": "projectHasDotGit",
+            "versionID": 1,
+            "createdAt": "2018-02-05T15:30:00Z",
+            "email": "michael.walker@overleaf.com",
+            "name": "msw"
+        },
+        "getSavedVers": [],
+        "getForVers": [],
+        "push": "success",
+        "postback": {
+            "type": "outOfDate"
+        }
+    }
+]


### PR DESCRIPTION
Closes https://github.com/overleaf/issues/issues/1861

Handles a new error case produced in https://github.com/overleaf/web-internal/pull/1817 . We want to prevent git-bridge from operating on a project which has a `.git` directory, because those projects can break the git-bridge. 

Web now checks for this condition and produces a 409 error, with a specific code. This PR makes git-bridge print a nice message when this error occurs.