### PR TITLE
Tell user to remove .git folder

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/Request.java
@@ -86,6 +86,8 @@ public abstract class Request<T extends Result> {
                                     "already a git repository. The Overleaf git-bridge cannot work with this project",
                                     "due to a known problem with handling these '.git' folders.",
                                     "",
+                                    "We recommend removing the .git folder before trying again.",
+                                    "",
                                     "If this is unexpected, please contact us at support@overleaf.com, or",
                                     "see https://www.overleaf.com/help/342 for more information."
                             ));


### PR DESCRIPTION
Update the message the user sees when their push/pull is rejected due to the project containing a `.git` folder.

Follow on from https://github.com/overleaf/writelatex-git-bridge/pull/65

This wording asks the user to remove the `.git` folder and try again. Hopefully they'll do this before falling through to "contact support" as the last option.

cc @jdleesmiller 