### PR TITLE
Encode file path when building url, allows unicode

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/data/CandidateSnapshot.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/CandidateSnapshot.java
@@ -5,10 +5,13 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import uk.ac.ic.wlgitbridge.data.filestore.RawFile;
 import uk.ac.ic.wlgitbridge.data.filestore.RawDirectory;
+import uk.ac.ic.wlgitbridge.util.Log;
 import uk.ac.ic.wlgitbridge.util.Util;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -115,10 +118,17 @@ public class CandidateSnapshot implements AutoCloseable {
         JsonObject jsonFile = new JsonObject();
         jsonFile.addProperty("name", file.getPath());
         if (file.isChanged()) {
-            jsonFile.addProperty(
-                    "url",
-                    projectURL + "/" + file.getPath() + "?key=" + postbackKey
-            );
+            String path = file.getPath();
+            String encodedPath;
+            try {
+                encodedPath = URLEncoder.encode(path, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                // This should never happen
+                Log.error("Error while encoding file path: projectUrl={}, path={}", projectURL, path, e);
+                encodedPath = path;
+            }
+            String url = projectURL + "/" + encodedPath + "?key=" + postbackKey;
+            jsonFile.addProperty("url", url);
         }
         return jsonFile;
     }


### PR DESCRIPTION
This fixes an issue where files with unicode characters would generate a `400` error in git-bridge, when the web api tries to fetch that file content.

Without this change, a url like `/project/x/ó.tex/y` would be generated, which the git-bridge would then reject at the framework level. With this change the file-path is url-encoded, so git-bridge serves the file properly.

Closes https://github.com/overleaf/issues/issues/1562

## Review

One issue, the encoder throws a `UnsupportedEncodingException` exception, which will never happen because we hard-code the encoding to `"UTF-8"`, but we need to either catch the exception, or add it to every function up the stack.

I went with catching and continuing, but this feels like a bit of a hack, as it will potentially silently corrupt users data just like in the original bug report (if this exception is, somehow, ever thrown). Open to feedback on that.