### PR TITLE
Use UUID in file url, not (encoded) file path.

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/data/CandidateSnapshot.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/CandidateSnapshot.java
@@ -5,13 +5,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import uk.ac.ic.wlgitbridge.data.filestore.RawFile;
 import uk.ac.ic.wlgitbridge.data.filestore.RawDirectory;
-import uk.ac.ic.wlgitbridge.util.Log;
 import uk.ac.ic.wlgitbridge.util.Util;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -80,7 +77,7 @@ public class CandidateSnapshot implements AutoCloseable {
         );
         for (ServletFile file : files) {
             if (file.isChanged()) {
-                file.writeToDisk(attsDirectory);
+                file.writeToDiskWithName(attsDirectory, file.getUniqueIdentifier());
             }
         }
     }
@@ -118,16 +115,8 @@ public class CandidateSnapshot implements AutoCloseable {
         JsonObject jsonFile = new JsonObject();
         jsonFile.addProperty("name", file.getPath());
         if (file.isChanged()) {
-            String path = file.getPath();
-            String encodedPath;
-            try {
-                encodedPath = URLEncoder.encode(path, "UTF-8");
-            } catch (UnsupportedEncodingException e) {
-                // This should never happen
-                Log.error("Error while encoding file path: projectUrl={}, path={}", projectURL, path, e);
-                encodedPath = path;
-            }
-            String url = projectURL + "/" + encodedPath + "?key=" + postbackKey;
+            String identifier = file.getUniqueIdentifier();
+            String url = projectURL + "/" + identifier + "?key=" + postbackKey;
             jsonFile.addProperty("url", url);
         }
         return jsonFile;

--- a/src/main/java/uk/ac/ic/wlgitbridge/data/ServletFile.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/ServletFile.java
@@ -1,6 +1,7 @@
 package uk.ac.ic.wlgitbridge.data;
 
 import uk.ac.ic.wlgitbridge.data.filestore.RawFile;
+import java.util.UUID;
 
 /**
  * Created by Winston on 21/02/15.
@@ -9,11 +10,15 @@ public class ServletFile extends RawFile {
 
     private final RawFile file;
     private final boolean changed;
+    private String uuid;
 
     public ServletFile(RawFile file, RawFile oldFile) {
         this.file = file;
+        this.uuid = UUID.randomUUID().toString();
         changed = !equals(oldFile);
     }
+
+    public String getUniqueIdentifier() { return uuid; }
 
     @Override
     public String getPath() {
@@ -38,5 +43,4 @@ public class ServletFile extends RawFile {
     public String toString() {
         return getPath();
     }
-
 }

--- a/src/main/java/uk/ac/ic/wlgitbridge/data/filestore/RawFile.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/filestore/RawFile.java
@@ -20,7 +20,11 @@ public abstract class RawFile {
     public abstract long size();
 
     public final void writeToDisk(File directory) throws IOException {
-        File file = new File(directory, getPath());
+        writeToDiskWithName(directory, getPath());
+    }
+
+    public final void writeToDiskWithName(File directory, String name) throws IOException {
+        File file = new File(directory, name);
         file.getParentFile().mkdirs();
         file.createNewFile();
         OutputStream out = new FileOutputStream(file);


### PR DESCRIPTION
This fixes a bunch of issues where funny characters in the file path
(spaces, unicode, etc) would cause the file server in this process to
respond with a 404 when asked for the file. The 404 would then cause
the push to fail.

We tried using url-encoding on the file path, but it turned out to still have problems.
Hence that code is removed by this PR.

Now we just use a UUID as an opaque and unambiguous identifier for each file.

## Related Issues

- Solving a related problem in web: https://github.com/overleaf/web-internal/pull/1940
- Root issue: https://github.com/overleaf/issues/issues/1835


## Sample Output

With this PR, when we push at snapshot to the web-api, the files have urls like this:

```
/api/5d1de4c726a07e0509c7086a/ee0c6e5a-b5c4-4e69-a924-52f9389d2008
```

Which is an improvement over:

```
/api/5d1de4c726a07e0509c7086a/some/path with spaces/ and a̳͍̥̩s͔͎̫̗s̨͎͕̰̲͕̬̙oŕ̫̳̦̞̖̝te͈̤̤͎̲d̞̳͚͖ ̷͈̦̱͖u̘̺͔̳͕͔̕n̥͖͚̼͕̹͟i̸͈͙͙̱c̵̜o̜̘̩̭d̩͡e̸ ̶̦̱͈̤͍t͞ŕ̰̱͈̲a̮̱̻͉̜͇s̭̗̝h̖̳͚̣ embedded/in/it.txt
```

## Manual Testing

- [x] Pushes with weird stuff (spaces, unicode, etc) work
- [x] The usual clone/pull/push workflow is ok

