### PR TITLE
EXPERIMENT DO NOT MERGE - Switch to nixos for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-# Dockerfile for git-bridge
+FROM nixos/nix
 
-FROM maven:3-jdk-8
-
-RUN apt-get update && apt-get install -y make git curl
+RUN nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
+RUN nix-channel --update
+RUN nix-env -i gnumake git
+RUN nix-env -iA nixpkgs.openjdk nixpkgs.maven
+RUN nix-store --gc
 
 WORKDIR /app


### PR DESCRIPTION
Part of hackathon, September 2019

Use nixos as a base for the docker image, and use nix to install dependencies.

```bash
-> % bin/exec git-bridge sh
3c951004ad1f:/app# which nix
/root/.nix-profile/bin/nix
3c951004ad1f:/app# which javac
/root/.nix-profile/bin/javac
3c951004ad1f:/app# which mvn
/root/.nix-profile/bin/mvn
3c951004ad1f:/app# ls -la /root/.nix-profile/bin
total 276
dr-xr-xr-x    2 root     root          4096 Jan  1  1970 .
dr-xr-xr-x    8 root     root          4096 Jan  1  1970 ..
...
lrwxrwxrwx    1 root     root            62 Jan  1  1970 git -> /nix/store/8sr48l861n57nw97wwjsqr21ncpwqkbw-git-2.22.0/bin/git
...
lrwxrwxrwx    1 root     root            70 Jan  1  1970 javac -> /nix/store/in5660fbafwjz33fg895arqjz2v1mx8x-openjdk-8u212-ga/bin/javac
...
lrwxrwxrwx    1 root     root            66 Jan  1  1970 make -> /nix/store/6g1vx8239mrxa1apicld1nbihminadsx-gnumake-4.2.1/bin/make
lrwxrwxrwx    1 root     root            70 Jan  1  1970 mvn -> /nix/store/qkasc80zqa5vwjssq7qki8fpvlg8qqp0-apache-maven-3.6.1/bin/mvn
...
lrwxrwxrwx    1 root     root            61 Jan  1  1970 nix -> /nix/store/5hdmx9yk7gr71b98j4vh9271k0zg5jis-nix-2.2.1/bin/nix
lrwxrwxrwx    1 root     root            67 Jan  1  1970 nix-build -> /nix/store/5hdmx9yk7gr71b98j4vh9271k0zg5jis-nix-2.2.1/bin/nix-build
lrwxrwxrwx    1 root     root            69 Jan  1  1970 nix-channel -> /nix/store/5hdmx9yk7gr71b98j4vh9271k0zg5jis-nix-2.2.1/bin/nix-channel
lrwxrwxrwx    1 root     root            77 Jan  1  1970 nix-collect-garbage -> /nix/store/5hdmx9yk7gr71b98j4vh9271k0zg5jis-nix-2.2.1/bin/nix-collect-garbage
lrwxrwxrwx    1 root     root            74 Jan  1  1970 nix-copy-closure -> /nix/store/5hdmx9yk7gr71b98j4vh9271k0zg5jis-nix-2.2.1/bin/nix-copy-closure
lrwxrwxrwx    1 root     root            68 Jan  1  1970 nix-daemon -> /nix/store/5hdmx9yk7gr71b98j4vh9271k0zg5jis-nix-2.2.1/bin/nix-daemon
lrwxrwxrwx    1 root     root            65 Jan  1  1970 nix-env -> /nix/store/5hdmx9yk7gr71b98j4vh9271k0zg5jis-nix-2.2.1/bin/nix-env
...
```