### PR TITLE
pass client ip as header

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/server/Oauth2Filter.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/Oauth2Filter.java
@@ -133,7 +133,11 @@ public class Oauth2Filter implements Filter {
 
         String authHeader = request.getHeader("Authorization");
         if (authHeader != null) {
-            Log.info("[{}] Authorization header present");
+            String clientIp = request.getHeader("X-Forwarded-For");
+            if (clientIp == null) {
+              clientIp = request.getRemoteAddr();
+            }
+            Log.info("[{}] Authorization header present", clientIp);
             StringTokenizer st = new StringTokenizer(authHeader);
             if (st.hasMoreTokens()) {
                 String basic = st.nextToken();
@@ -157,7 +161,8 @@ public class Oauth2Filter implements Filter {
                                         Instance.jsonFactory,
                                         new GenericUrl(
                                                 oauth2.getOauth2Server()
-                                                        + "/oauth/token"
+                                                        + "/oauth/token?client_ip="
+                                                        + clientIp
                                         ),
                                         username,
                                         password


### PR DESCRIPTION
Get IP address from either X-Forwarded-For or the client IP. Pass as `client_id` url parameter on oauth api requests.

In the future the web api will use this to do ip based rate limiting.