### PR TITLE
debug http headers

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/server/Oauth2Filter.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/Oauth2Filter.java
@@ -138,6 +138,12 @@ public class Oauth2Filter implements Filter {
               clientIp = request.getRemoteAddr();
             }
             Log.info("[{}] Authorization header present", clientIp);
+            // TEMPORARY DEBUG CODE
+            Enumeration headerNames = request.getHeaderNames();
+            while(headerNames.hasMoreElements()) {
+              String headerName = (String)headerNames.nextElement();
+              Log.info("HEADER {}: {}", headerName, request.getHeader(headerName));
+            }
             StringTokenizer st = new StringTokenizer(authHeader);
             if (st.hasMoreTokens()) {
                 String basic = st.nextToken();


### PR DESCRIPTION
Debug all http headers to try and find real client ip header.

Related: overleaf/web-internal/pull/2389

We added some code earlier to try and extract the client ip from the x-forwarded-for header but from trailing the logs in production that is still showing internal ips so adding this to debug the http headers and see if we can get the real client ip.