### PR TITLE
Add `/api/status` and `/api/health_check` endpoints

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
@@ -266,6 +266,10 @@ public class Bridge {
     public boolean healthCheck() {
        try {
          dbStore.getNumProjects();
+         File rootDirectory = new File("/");
+         if (!rootDirectory.exists()) {
+           throw new Exception("bad filesystem state, root directory does not exist");
+         }
          Log.error("[HealthCheck] passed");
          return true;
        } catch (Exception e)  {

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
@@ -263,6 +263,17 @@ public class Bridge {
         gcJob.start();
     }
 
+    public boolean healthCheck() {
+       try {
+         dbStore.getNumProjects();
+         Log.error("[HealthCheck] passed");
+         return true;
+       } catch (Exception e)  {
+         Log.error("[HealthCheck] FAILED!", e);
+         return false;
+       }
+    }
+
     /**
      * Performs a check of inconsistencies in the DB. This was used to upgrade
      * the schema.

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
@@ -270,7 +270,7 @@ public class Bridge {
          if (!rootDirectory.exists()) {
            throw new Exception("bad filesystem state, root directory does not exist");
          }
-         Log.error("[HealthCheck] passed");
+         Log.info("[HealthCheck] passed");
          return true;
        } catch (Exception e)  {
          Log.error("[HealthCheck] FAILED!", e);

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -128,6 +128,7 @@ public class GitBridgeServer {
         api.setContextPath("/api");
 
         HandlerCollection handlers = new HandlerList();
+        handlers.addHandler(new StatusHandler(bridge));
         handlers.addHandler(initResourceHandler());
         handlers.addHandler(new PostbackHandler(bridge));
         handlers.addHandler(new DefaultHandler());

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -119,8 +119,19 @@ public class GitBridgeServer {
     ) throws ServletException {
         HandlerCollection handlers = new HandlerList();
         handlers.addHandler(initApiHandler());
+        handlers.addHandler(initBaseHandler());
         handlers.addHandler(initGitHandler(config, repoStore, snapshotApi));
         jettyServer.setHandler(handlers);
+    }
+
+    private Handler initBaseHandler() {
+        ContextHandler base = new ContextHandler();
+        base.setContextPath("/");
+        HandlerCollection handlers = new HandlerList();
+        handlers.addHandler(new StatusHandler(bridge));
+        handlers.addHandler(new HealthCheckHandler(bridge));
+        base.setHandler(handlers);
+        return base;
     }
 
     private Handler initApiHandler() {
@@ -128,8 +139,6 @@ public class GitBridgeServer {
         api.setContextPath("/api");
 
         HandlerCollection handlers = new HandlerList();
-        handlers.addHandler(new StatusHandler(bridge));
-        handlers.addHandler(new HealthCheckHandler(bridge));
         handlers.addHandler(initResourceHandler());
         handlers.addHandler(new PostbackHandler(bridge));
         handlers.addHandler(new DefaultHandler());

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -129,6 +129,7 @@ public class GitBridgeServer {
 
         HandlerCollection handlers = new HandlerList();
         handlers.addHandler(new StatusHandler(bridge));
+        handlers.addHandler(new HealthCheckHandler(bridge));
         handlers.addHandler(initResourceHandler());
         handlers.addHandler(new PostbackHandler(bridge));
         handlers.addHandler(new DefaultHandler());

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
@@ -29,7 +29,7 @@ public class HealthCheckHandler extends AbstractHandler {
     HttpServletResponse response
   ) throws IOException {
     if ("GET".equals(baseRequest.getMethod()) && "/health_check".equals(target)) {
-      Log.info("GET <- /api/health_check");
+      Log.info("GET <- /health_check");
       baseRequest.setHandled(true);
       response.setContentType("text/plain");
       if (bridge.healthCheck()) {

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
@@ -32,8 +32,13 @@ public class HealthCheckHandler extends AbstractHandler {
       Log.info("GET <- /api/health_check");
       baseRequest.setHandled(true);
       response.setContentType("text/plain");
-      response.setStatus(200);
-      response.getWriter().println("ok");
+      if (bridge.healthCheck()) {
+        response.setStatus(200);
+        response.getWriter().println("ok");
+      } else {
+        response.setStatus(500);
+        response.getWriter().println("failed");
+      }
     }
   }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
@@ -1,0 +1,40 @@
+package uk.ac.ic.wlgitbridge.server;
+
+import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.ic.wlgitbridge.bridge.Bridge;
+import uk.ac.ic.wlgitbridge.util.Log;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class HealthCheckHandler extends AbstractHandler {
+
+  private final Bridge bridge;
+
+  public HealthCheckHandler(Bridge bridge) {
+    this.bridge = bridge;
+  }
+
+  @Override
+  public void handle(
+    String target,
+    Request baseRequest,
+    HttpServletRequest request,
+    HttpServletResponse response
+  ) throws IOException {
+    if ("GET".equals(baseRequest.getMethod()) && "/health_check".equals(target)) {
+      Log.info("GET <- /api/health_check");
+      baseRequest.setHandled(true);
+      response.setContentType("text/plain");
+      response.setStatus(200);
+      response.getWriter().println("ok");
+    }
+  }
+
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/StatusHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/StatusHandler.java
@@ -1,0 +1,40 @@
+package uk.ac.ic.wlgitbridge.server;
+
+import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.ic.wlgitbridge.bridge.Bridge;
+import uk.ac.ic.wlgitbridge.util.Log;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class StatusHandler extends AbstractHandler {
+
+  private final Bridge bridge;
+
+  public StatusHandler(Bridge bridge) {
+    this.bridge = bridge;
+  }
+
+  @Override
+  public void handle(
+    String target,
+    Request baseRequest,
+    HttpServletRequest request,
+    HttpServletResponse response
+  ) throws IOException {
+    if ("GET".equals(baseRequest.getMethod()) && "/status".equals(target)) {
+      Log.info("GET <- /api/status");
+      baseRequest.setHandled(true);
+      response.setContentType("text/plain");
+      response.setStatus(200);
+      response.getWriter().println("ok");
+    }
+  }
+
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/StatusHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/StatusHandler.java
@@ -29,7 +29,7 @@ public class StatusHandler extends AbstractHandler {
     HttpServletResponse response
   ) throws IOException {
     if ("GET".equals(baseRequest.getMethod()) && "/status".equals(target)) {
-      Log.info("GET <- /api/status");
+      Log.info("GET <- /status");
       baseRequest.setHandled(true);
       response.setContentType("text/plain");
       response.setStatus(200);

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -921,7 +921,7 @@ public class WLGitBridgeIntegrationTest {
         assertEquals(healthCheckResponse.getStatusLine().getStatusCode(), 200);
     }
 
-  private String makeConfigFile(
+    private String makeConfigFile(
             int port,
             int apiPort
     ) throws IOException {

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -910,12 +910,13 @@ public class WLGitBridgeIntegrationTest {
         });
         wlgb.run();
         HttpClient client = HttpClients.createDefault();
+        String urlBase = "http://127.0.0.1:" + gitBridgePort;
         // Status
-        HttpGet statusRequest = new HttpGet("http://127.0.0.1:"+gitBridgePort+"/api/status");
+        HttpGet statusRequest = new HttpGet(urlBase+"/api/status");
         HttpResponse statusResponse = client.execute(statusRequest);
         assertEquals(statusResponse.getStatusLine().getStatusCode(), 200);
         // Health Check
-        HttpGet healthCheckRequest = new HttpGet("http://127.0.0.1:"+gitBridgePort+"/api/health_check");
+        HttpGet healthCheckRequest = new HttpGet(urlBase+"/api/health_check");
         HttpResponse healthCheckResponse = client.execute(healthCheckRequest);
         assertEquals(healthCheckResponse.getStatusLine().getStatusCode(), 200);
     }

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -912,13 +912,13 @@ public class WLGitBridgeIntegrationTest {
         HttpClient client = HttpClients.createDefault();
         String urlBase = "http://127.0.0.1:" + gitBridgePort;
         // Status
-        HttpGet statusRequest = new HttpGet(urlBase+"/api/status");
+        HttpGet statusRequest = new HttpGet(urlBase+"/status");
         HttpResponse statusResponse = client.execute(statusRequest);
-        assertEquals(statusResponse.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, statusResponse.getStatusLine().getStatusCode());
         // Health Check
-        HttpGet healthCheckRequest = new HttpGet(urlBase+"/api/health_check");
+        HttpGet healthCheckRequest = new HttpGet(urlBase+"/health_check");
         HttpResponse healthCheckResponse = client.execute(healthCheckRequest);
-        assertEquals(healthCheckResponse.getStatusLine().getStatusCode(), 200);
+        assertEquals(200, healthCheckResponse.getStatusLine().getStatusCode());
     }
 
     private String makeConfigFile(


### PR DESCRIPTION
Part of https://github.com/overleaf/issues/issues/3081

These new endpoints will be useful for monitoring the git-bridge server process, and for restarting it if it becomes unresponsive.

The health-check endpoint does two things:
- tries to query the sqlite database
- tries to check if the root directory ("/") exists

If either of these actions fail, the health-check fails. Monitoring can then decide to reboot the process or server.


## Review, and Open Questions

It's debatable whether we actually need a "status" endpoint, but I've added it to match our other services.

Also, the base route of the server is at `/api/`, so the status route is `/api/status`, rather than just `/status`. We may want to change this, or maybe it's better to stay consistent with the rest of the server routes?