### PR TITLE
Handle HEAD method, and trailing slash on status and health-check calls

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
@@ -28,12 +28,13 @@ public class HealthCheckHandler extends AbstractHandler {
     HttpServletRequest request,
     HttpServletResponse response
   ) throws IOException {
+    String method = baseRequest.getMethod();
     if (
-      "GET".equals(baseRequest.getMethod())
+      ("GET".equals(method) || "HEAD".equals(method))
         && target != null
         && target.matches("^\\/health_check\\/?$")
     ) {
-      Log.info("GET <- /health_check");
+      Log.info(method + " <- /health_check");
       baseRequest.setHandled(true);
       response.setContentType("text/plain");
       if (bridge.healthCheck()) {

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
@@ -28,7 +28,11 @@ public class HealthCheckHandler extends AbstractHandler {
     HttpServletRequest request,
     HttpServletResponse response
   ) throws IOException {
-    if ("GET".equals(baseRequest.getMethod()) && "/health_check".equals(target)) {
+    if (
+      "GET".equals(baseRequest.getMethod())
+        && target != null
+        && target.matches("^\\/health_check\\/?$")
+    ) {
       Log.info("GET <- /health_check");
       baseRequest.setHandled(true);
       response.setContentType("text/plain");

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/HealthCheckHandler.java
@@ -32,7 +32,7 @@ public class HealthCheckHandler extends AbstractHandler {
     if (
       ("GET".equals(method) || "HEAD".equals(method))
         && target != null
-        && target.matches("^\\/health_check\\/?$")
+        && target.matches("^/health_check/?$")
     ) {
       Log.info(method + " <- /health_check");
       baseRequest.setHandled(true);

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/StatusHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/StatusHandler.java
@@ -12,6 +12,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 
 public class StatusHandler extends AbstractHandler {
 
@@ -28,12 +29,13 @@ public class StatusHandler extends AbstractHandler {
     HttpServletRequest request,
     HttpServletResponse response
   ) throws IOException {
+    String method = baseRequest.getMethod();
     if (
-      "GET".equals(baseRequest.getMethod())
+      ("GET".equals(method) || "HEAD".equals(method))
         && target != null
         && target.matches("^\\/status\\/?$")
     ) {
-      Log.info("GET <- /status");
+      Log.info(method + " <- /status");
       baseRequest.setHandled(true);
       response.setContentType("text/plain");
       response.setStatus(200);

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/StatusHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/StatusHandler.java
@@ -28,7 +28,11 @@ public class StatusHandler extends AbstractHandler {
     HttpServletRequest request,
     HttpServletResponse response
   ) throws IOException {
-    if ("GET".equals(baseRequest.getMethod()) && "/status".equals(target)) {
+    if (
+      "GET".equals(baseRequest.getMethod())
+        && target != null
+        && target.matches("^\\/status\\/?$")
+    ) {
       Log.info("GET <- /status");
       baseRequest.setHandled(true);
       response.setContentType("text/plain");

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/StatusHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/StatusHandler.java
@@ -33,7 +33,7 @@ public class StatusHandler extends AbstractHandler {
     if (
       ("GET".equals(method) || "HEAD".equals(method))
         && target != null
-        && target.matches("^\\/status\\/?$")
+        && target.matches("^/status/?$")
     ) {
       Log.info(method + " <- /status");
       baseRequest.setHandled(true);

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -921,6 +921,29 @@ public class WLGitBridgeIntegrationTest {
         assertEquals(200, healthCheckResponse.getStatusLine().getStatusCode());
     }
 
+    @Test
+    public void testStatusAndHealthCheckEndpointsWithTrailingSlash() throws ClientProtocolException, IOException {
+        int gitBridgePort = 33888;
+        int mockServerPort = 3888;
+        server = new MockSnapshotServer(mockServerPort, getResource("/canCloneARepository").toFile());
+        server.start();
+        server.setState(states.get("canCloneARepository").get("state"));
+        wlgb = new GitBridgeApp(new String[] {
+          makeConfigFile(gitBridgePort, mockServerPort)
+        });
+        wlgb.run();
+        HttpClient client = HttpClients.createDefault();
+        String urlBase = "http://127.0.0.1:" + gitBridgePort;
+        // Status
+        HttpGet statusRequest = new HttpGet(urlBase+"/status/");
+        HttpResponse statusResponse = client.execute(statusRequest);
+        assertEquals(200, statusResponse.getStatusLine().getStatusCode());
+        // Health Check
+        HttpGet healthCheckRequest = new HttpGet(urlBase+"/health_check/");
+        HttpResponse healthCheckResponse = client.execute(healthCheckRequest);
+        assertEquals(200, healthCheckResponse.getStatusLine().getStatusCode());
+    }
+
     private String makeConfigFile(
             int port,
             int apiPort

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -9,6 +9,7 @@ import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
 import org.apache.http.impl.client.HttpClients;
 import org.asynchttpclient.*;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -940,6 +941,29 @@ public class WLGitBridgeIntegrationTest {
         assertEquals(200, statusResponse.getStatusLine().getStatusCode());
         // Health Check
         HttpGet healthCheckRequest = new HttpGet(urlBase+"/health_check/");
+        HttpResponse healthCheckResponse = client.execute(healthCheckRequest);
+        assertEquals(200, healthCheckResponse.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void testStatusAndHealthCheckEndpointsWithHead() throws ClientProtocolException, IOException {
+        int gitBridgePort = 33889;
+        int mockServerPort = 3889;
+        server = new MockSnapshotServer(mockServerPort, getResource("/canCloneARepository").toFile());
+        server.start();
+        server.setState(states.get("canCloneARepository").get("state"));
+        wlgb = new GitBridgeApp(new String[] {
+          makeConfigFile(gitBridgePort, mockServerPort)
+        });
+        wlgb.run();
+        HttpClient client = HttpClients.createDefault();
+        String urlBase = "http://127.0.0.1:" + gitBridgePort;
+        // Status
+        HttpHead statusRequest = new HttpHead(urlBase+"/status");
+        HttpResponse statusResponse = client.execute(statusRequest);
+        assertEquals(200, statusResponse.getStatusLine().getStatusCode());
+        // Health Check
+        HttpHead healthCheckRequest = new HttpHead(urlBase+"/health_check");
         HttpResponse healthCheckResponse = client.execute(healthCheckRequest);
         assertEquals(200, healthCheckResponse.getStatusLine().getStatusCode());
     }


### PR DESCRIPTION
Part of https://github.com/overleaf/issues/issues/3081

Speculative fix for an issue with monit.
It seems that monit adds a trailing slash after the specified url, and thus does not get handled by the Health-Check handler, and falls through to the main git handlers instead, resulting in a 404 response.