### PR TITLE
Handle Git LFS requests, with error message

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -130,6 +130,7 @@ public class GitBridgeServer {
         HandlerCollection handlers = new HandlerList();
         handlers.addHandler(new StatusHandler(bridge));
         handlers.addHandler(new HealthCheckHandler(bridge));
+        handlers.addHandler(new GitLfsHandler(bridge));
         base.setHandler(handlers);
         return base;
     }

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitLfsHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitLfsHandler.java
@@ -1,0 +1,46 @@
+package uk.ac.ic.wlgitbridge.server;
+
+import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.ic.wlgitbridge.bridge.Bridge;
+import uk.ac.ic.wlgitbridge.util.Log;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class GitLfsHandler extends AbstractHandler {
+
+  private final Bridge bridge;
+
+  public GitLfsHandler(Bridge bridge) {
+    this.bridge = bridge;
+  }
+
+  @Override
+  public void handle(
+    String target,
+    Request baseRequest,
+    HttpServletRequest request,
+    HttpServletResponse response
+  ) throws IOException {
+    String method = baseRequest.getMethod();
+    if (
+      ("POST".equals(method))
+        && target != null
+        && target.matches("^/[0-9a-z]+\\.git/info/lfs/objects/batch/?$")
+    ) {
+      Log.info(method + " <- /<project>.git/info/lfs/objects/batch");
+      response.setContentType("application/vnd.git-lfs+json");
+      response.setStatus(406);
+      response.getWriter().println("{\"message\": \"ERROR: Git LFS is not supported on Overleaf\"}");
+      baseRequest.setHandled(true);
+    }
+  }
+
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitLfsHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitLfsHandler.java
@@ -37,7 +37,7 @@ public class GitLfsHandler extends AbstractHandler {
     ) {
       Log.info(method + " <- /<project>.git/info/lfs/objects/batch");
       response.setContentType("application/vnd.git-lfs+json");
-      response.setStatus(406);
+      response.setStatus(422);
       response.getWriter().println("{\"message\": \"ERROR: Git LFS is not supported on Overleaf\"}");
       baseRequest.setHandled(true);
     }

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -989,7 +989,7 @@ public class WLGitBridgeIntegrationTest {
         String urlBase = "http://127.0.0.1:" + gitBridgePort;
         HttpPost gitLfsRequest = new HttpPost(urlBase+"/5f2419407929eb0026641967.git/info/lfs/objects/batch");
         HttpResponse gitLfsResponse = client.execute(gitLfsRequest);
-        assertEquals(406, gitLfsResponse.getStatusLine().getStatusCode());
+        assertEquals(422, gitLfsResponse.getStatusLine().getStatusCode());
         HttpEntity entity = gitLfsResponse.getEntity();
         String responseString = EntityUtils.toString(entity, "UTF-8");
         assertTrue(responseString.contains("Git LFS is not supported on Overleaf"));


### PR DESCRIPTION
We don't support Git LFS. This change adds a handler for POST requests to "<project>.git/info/lfs/objects/batch", and sends back a 406 response, with json data that the client can use to print a nice error message.


## Examples

```
❯ git push
batch response: ERROR: Git LFS is not supported on Overleaf                                              
error: failed to push some refs to 'https://git.dev-overleaf.com/5f2419407929eb0026641967'
```


## Related Issues/PRs

- Fixes https://github.com/overleaf/issues/issues/3294


## Resources

- Git LFS Batch API documentation: https://github.com/git-lfs/git-lfs/blob/master/docs/api/batch.md

