### PR TITLE
When logging IOException for put, include error

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
@@ -473,7 +473,7 @@ public class Bridge {
             );
             throw e;
         } catch (IOException e) {
-            Log.warn("[{}] IOException on put", projectName);
+            Log.warn("[{}] IOException on put: {}", projectName, e);
             throw e;
         }
 


### PR DESCRIPTION
Found this log line while debugging a git-bridge problem in production. Would have been useful to have the text of the specific error here.