### PR TITLE
Add PostgreSQL support to database layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ To be run from the dev-environment:
 **Clean**:
 `bin/run git-bridge make clean`
 
+
 ### Installation
 
 Install dependencies:
@@ -61,6 +62,26 @@ Create a config file according to the format below.
 Run `mvn package` to build, test, and package it into a jar at `target/writelatex-git-bridge-1.0-SNAPSHOT-jar-with-dependencies.jar`.
 
 Use `java -jar <path_to_jar> <path_to_config_file>` to run the server.
+
+
+### Create Postgres Database and Tables
+
+From the dev-environment, run:
+
+``` sh
+$ bin/gitbridge-setup-db
+$ bin/gitbridge-setup-tables
+```
+
+See `create-tables.sql` for the relevant SQL.
+
+Run the following to set up the test database:
+
+``` sh
+$ bin/gitbridge-setup-db --test
+$ bin/gitbridge-setup-tables --test
+```
+
 
 ## Runtime Configuration
 

--- a/conf/example_config.json
+++ b/conf/example_config.json
@@ -22,6 +22,17 @@
         "s3BucketName": "com.overleaf.testbucket",
         "awsRegion": "us-east-1"
     },
+    "database": {
+        "type": "postgres",
+        "options": {
+            "url": "jdbc:postgresql://postgres_v2/gitbridge",
+            "username": "sharelatex",
+            "password": "sharelatex",
+            "poolInitialSize": 2,
+            "poolMaxTotal": 8,
+            "poolMaxWaitMillis": 20000
+        }
+    },
     "swapJob": {
         "minProjects": 50,
         "lowGiB": 128,

--- a/conf/local.json
+++ b/conf/local.json
@@ -18,6 +18,17 @@
     "swapStore": {
         "type": "noop"
     },
+    "database": {
+      "type": "postgres",
+      "options": {
+        "url": "jdbc:postgresql://postgres_v2/gitbridge",
+        "username": "sharelatex",
+        "password": "sharelatex",
+        "poolInitialSize": 2,
+        "poolMaxTotal": 8,
+        "poolMaxWaitMillis": 20000
+      }
+    },
     "swapJob": {
         "minProjects": 50,
         "lowGiB": 128,

--- a/create-tables.sql
+++ b/create-tables.sql
@@ -3,7 +3,10 @@ BEGIN;
   CREATE TABLE IF NOT EXISTS public.projects (
     "name" varchar(100) NOT NULL DEFAULT ''::character varying,
     version_id int4 NOT NULL DEFAULT 0,
-    last_accessed timestamptz NULL,
+    last_accessed timestamptz NULL,  -- when null, project is swapped
+    swap_time timestamptz NULL,
+    restore_time timestamptz NULL,
+    swap_compression varchar(100) NULL,
     CONSTRAINT projects_pkey PRIMARY KEY (name)
   );
   CREATE INDEX IF NOT EXISTS projects_index_last_accessed

--- a/create-tables.sql
+++ b/create-tables.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+  CREATE TABLE IF NOT EXISTS public.projects (
+    "name" varchar(100) NOT NULL DEFAULT ''::character varying,
+    version_id int4 NOT NULL DEFAULT 0,
+    last_accessed timestamptz NULL,
+    CONSTRAINT projects_pkey PRIMARY KEY (name)
+  );
+  CREATE INDEX IF NOT EXISTS projects_index_last_accessed
+    ON public.projects
+    USING btree
+    (last_accessed);
+
+  CREATE TABLE IF NOT EXISTS public.url_index_store (
+    project_name varchar(100) NOT NULL DEFAULT ''::character varying,
+    url varchar(2000) NOT NULL,
+    "path" varchar(2000) NOT NULL,
+    CONSTRAINT url_index_store_pkey PRIMARY KEY (project_name, url)
+  );
+  CREATE UNIQUE INDEX IF NOT EXISTS project_path_index
+    ON public.url_index_store
+    USING btree
+    (project_name, path);
+COMMIT;

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,19 @@
         </plugins>
     </build>
     <dependencies>
-        <!-- https://mvnrepository.com/artifact/junit/junit -->
+      <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-dbcp2 -->
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-dbcp2</artifactId>
+        <version>2.8.0</version>
+      </dependency>
+      <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
+      <dependency>
+          <groupId>org.postgresql</groupId>
+          <artifactId>postgresql</artifactId>
+          <version>42.2.18</version>
+      </dependency>
+      <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/uk/ac/ic/wlgitbridge/application/config/Config.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/application/config/Config.java
@@ -4,6 +4,10 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import uk.ac.ic.wlgitbridge.application.exception.ConfigFileException;
+import uk.ac.ic.wlgitbridge.bridge.db.DatabaseConfig;
+import uk.ac.ic.wlgitbridge.bridge.db.postgres.PostgresConfig;
+import uk.ac.ic.wlgitbridge.bridge.db.postgres.PostgresOptions;
+import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SqliteConfig;
 import uk.ac.ic.wlgitbridge.bridge.repo.RepoStoreConfig;
 import uk.ac.ic.wlgitbridge.bridge.swap.job.SwapJobConfig;
 import uk.ac.ic.wlgitbridge.bridge.swap.store.SwapStoreConfig;
@@ -21,7 +25,12 @@ import java.util.Optional;
  */
 public class Config implements JSONSource {
 
+
     static Config asSanitised(Config config) {
+        DatabaseConfig sanitizedDatabaseConfig = null;
+        if (null != config.database) {
+          sanitizedDatabaseConfig = config.database.asSanitized();
+        }
         return new Config(
                 config.port,
                 config.rootGitDirectory,
@@ -33,7 +42,8 @@ public class Config implements JSONSource {
                 Oauth2.asSanitised(config.oauth2),
                 config.repoStore,
                 SwapStoreConfig.sanitisedCopy(config.swapStore),
-                config.swapJob
+                config.swapJob,
+                sanitizedDatabaseConfig
         );
     }
 
@@ -52,6 +62,8 @@ public class Config implements JSONSource {
     private SwapStoreConfig swapStore;
     @Nullable
     private SwapJobConfig swapJob;
+    @Nullable
+    private DatabaseConfig database;
 
     public Config(
             String configFilePath
@@ -75,7 +87,8 @@ public class Config implements JSONSource {
             Oauth2 oauth2,
             RepoStoreConfig repoStore,
             SwapStoreConfig swapStore,
-            SwapJobConfig swapJob
+            SwapJobConfig swapJob,
+            DatabaseConfig database
     ) {
         this.port = port;
         this.rootGitDirectory = rootGitDirectory;
@@ -88,6 +101,7 @@ public class Config implements JSONSource {
         this.repoStore = repoStore;
         this.swapStore = swapStore;
         this.swapJob = swapJob;
+        this.database = database;
     }
 
     @Override
@@ -124,6 +138,22 @@ public class Config implements JSONSource {
                 configObject.get("swapJob"),
                 SwapJobConfig.class
         );
+
+        JsonObject databaseElement = configObject.getAsJsonObject("database");
+        if (null != databaseElement) {
+          String databaseType = databaseElement.get("type").getAsString();
+          if ("postgres".equals(databaseType)) {
+            PostgresOptions postgresOptions = new Gson().fromJson(
+              databaseElement.get("options"),
+              PostgresOptions.class
+            );
+            database = new PostgresConfig(postgresOptions);
+          } else {
+            database = new SqliteConfig();
+          }
+        } else {
+          database = null;
+        }
     }
 
     public String getSanitisedString() {
@@ -179,6 +209,10 @@ public class Config implements JSONSource {
 
     public Optional<SwapJobConfig> getSwapJob() {
         return Optional.ofNullable(swapJob);
+    }
+
+    public Optional<DatabaseConfig> getDatabase() {
+      return Optional.ofNullable(database);
     }
 
     private JsonElement getElement(JsonObject configObject, String name) {

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DBStore.java
@@ -1,7 +1,16 @@
 package uk.ac.ic.wlgitbridge.bridge.db;
 
+import uk.ac.ic.wlgitbridge.bridge.db.postgres.PostgresConfig;
+import uk.ac.ic.wlgitbridge.bridge.db.postgres.PostgresDBStore;
+import uk.ac.ic.wlgitbridge.bridge.db.postgres.PostgresOptions;
+import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SqliteDBStore;
+import uk.ac.ic.wlgitbridge.bridge.repo.RepoStore;
+import uk.ac.ic.wlgitbridge.util.Log;
+
+import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Created by winston on 20/08/2016.
@@ -41,4 +50,21 @@ public interface DBStore {
      */
     void setLastAccessedTime(String projectName, Timestamp time);
 
+    static DBStore fromConfig(Optional<DatabaseConfig> maybeConfig, RepoStore repoStore) {
+      if (
+        maybeConfig.isPresent() &&
+        maybeConfig.get().getDatabaseType() == DatabaseConfig.DatabaseType.Postgres
+      ) {
+        Log.info("Database: connect to postgres");
+        PostgresOptions options = ((PostgresConfig)maybeConfig.get()).getOptions();
+        return new PostgresDBStore(options);
+      } else {
+        Log.info("Database: connect to sqlite");
+        return new SqliteDBStore(
+          Paths.get(
+            repoStore.getRootDirectory().getAbsolutePath()
+          ).resolve(".wlgb").resolve("wlgb.db").toFile()
+        );
+      }
+    }
 }

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DatabaseConfig.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DatabaseConfig.java
@@ -1,0 +1,10 @@
+package uk.ac.ic.wlgitbridge.bridge.db;
+
+public interface DatabaseConfig {
+  enum DatabaseType {SQLite, Postgres};
+
+  DatabaseType getDatabaseType();
+
+  public DatabaseConfig asSanitized();
+
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresConfig.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresConfig.java
@@ -1,0 +1,32 @@
+package uk.ac.ic.wlgitbridge.bridge.db.postgres;
+
+import uk.ac.ic.wlgitbridge.bridge.db.DatabaseConfig;
+
+public class PostgresConfig implements DatabaseConfig {
+  private final PostgresOptions options;
+
+  public PostgresConfig(PostgresOptions options) {
+    this.options = options;
+  }
+
+  @Override
+  public DatabaseType getDatabaseType() {
+    return DatabaseType.Postgres;
+  }
+
+  public PostgresOptions getOptions() {
+    return options;
+  }
+
+  @Override
+  public DatabaseConfig asSanitized() {
+    return new PostgresConfig(new PostgresOptions(
+      "<REDACTED>",
+      "<REDACTED>",
+      "<REDACTED>",
+      options.getPoolInitialSize(),
+      options.getPoolMaxTotal(),
+      options.getPoolMaxWaitMillis()
+    ));
+  }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresDBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresDBStore.java
@@ -1,0 +1,274 @@
+package uk.ac.ic.wlgitbridge.bridge.db.postgres;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import org.postgresql.jdbc2.optional.ConnectionPool;
+import uk.ac.ic.wlgitbridge.bridge.db.DBInitException;
+import uk.ac.ic.wlgitbridge.bridge.db.DBStore;
+import uk.ac.ic.wlgitbridge.bridge.db.ProjectState;
+import uk.ac.ic.wlgitbridge.util.Log;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PostgresDBStore implements DBStore {
+
+  private final BasicDataSource pool;
+
+  public PostgresDBStore(PostgresOptions options) {
+    Log.info("Initialize PostgresDBStore");
+    try {
+      pool = new BasicDataSource();
+      pool.setDriverClassName("org.postgresql.Driver");
+      pool.setUrl(options.getUrl());
+      pool.setUsername(options.getUsername());
+      pool.setPassword(options.getPassword());
+      int poolInitialSize = options.getPoolInitialSize();
+      int poolMaxTotal = options.getPoolMaxTotal();
+      int poolMaxWaitMillis = options.getPoolMaxWaitMillis();
+      if (poolInitialSize < 1) {
+        throw new RuntimeException("Invalid poolInitialSize: " + poolInitialSize);
+      }
+      if (poolMaxTotal < poolInitialSize) {
+        throw new RuntimeException("Invalid poolMaxTotal and poolInitialSize: " + poolMaxTotal + ", " + poolInitialSize);
+      }
+      pool.setInitialSize(poolInitialSize);
+      pool.setMaxTotal(poolMaxTotal);
+      pool.setMaxWaitMillis(poolMaxWaitMillis);
+    } catch (Exception e) {
+      Log.error("Error connecting to Postgres: {}", e.getMessage());
+      throw new DBInitException(e);
+    }
+  }
+
+  @Override
+  public int getNumProjects() {
+    try (
+      Connection connection = pool.getConnection();
+      Statement statement = connection.createStatement();
+         ResultSet rs = statement.executeQuery("SELECT count(*) from projects;\n")) {
+      if (rs.next()) {
+        int result = rs.getInt(1);
+        return result;
+      } else {
+        return 0;
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  };
+
+  @Override
+  public List<String> getProjectNames() {
+    try (
+      Connection connection = pool.getConnection();
+      Statement statement = connection.createStatement();
+         ResultSet rs = statement.executeQuery("SELECT name from projects;\n")) {
+      List<String> result = new ArrayList<String>();
+      while (rs.next()) {
+        result.add(rs.getString(1));
+      }
+      return result;
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  };
+
+  @Override
+  public void setLatestVersionForProject(String project, int versionID) {
+    try (
+      Connection connection = pool.getConnection();
+      PreparedStatement statement = connection.prepareStatement(
+        "INSERT INTO "
+           + "projects (name, version_id, last_accessed) "
+           + "VALUES (?, ?, now()) "
+           + "ON CONFLICT (name) DO UPDATE "
+           + "SET version_id = EXCLUDED.version_id, last_accessed = now();\n")) {
+      statement.setString(1, project);
+      statement.setInt(2, versionID);
+      statement.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  };
+
+  @Override
+  public int getLatestVersionForProject(String project) {
+    try (
+      Connection connection = pool.getConnection();
+      PreparedStatement statement = connection.prepareStatement(
+        "SELECT version_id from projects where name = ?;")) {
+      statement.setString(1, project);
+      try (ResultSet rs = statement.executeQuery()) {
+        if (rs.next()) {
+          int versionId = rs.getInt(1);
+          return versionId;
+        } else {
+          return 0;
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  };
+
+  @Override
+  public void addURLIndexForProject(String projectName, String url, String path) {
+    try (
+      Connection connection = pool.getConnection();
+      PreparedStatement statement = connection.prepareStatement(
+      "INSERT INTO url_index_store(" +
+         "project_name, " +
+         "url, " +
+         "path" +
+         ") VALUES " +
+         "(?, ?, ?)" +
+         "ON CONFLICT (project_name,path) DO UPDATE " +
+         "SET url = EXCLUDED.url;\n")) {
+      statement.setString(1, projectName);
+      statement.setString(2, url);
+      statement.setString(3, path);
+      statement.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  };
+
+  @Override
+  public void deleteFilesForProject(String project, String... files) {
+    if (files.length == 0) {
+      return;
+    }
+    StringBuilder queryBuilder = new StringBuilder();
+    queryBuilder.append("DELETE FROM url_index_store ");
+    queryBuilder.append("WHERE project_name = ? AND path IN (");
+    for (int i = 0; i < files.length; i++) {
+      queryBuilder.append("?");
+      if (i < files.length - 1) {
+        queryBuilder.append(", ");
+      }
+    }
+    queryBuilder.append(");\n");
+    try (
+      Connection connection = pool.getConnection();
+      PreparedStatement statement = connection.prepareStatement(queryBuilder.toString())) {
+      statement.setString(1, project);
+      for (int i = 0; i < files.length; i++) {
+        statement.setString(i + 2, files[i]);
+      }
+      statement.execute();
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  };
+
+  @Override
+  public String getPathForURLInProject(String projectName, String url) {
+    try (
+      Connection connection = pool.getConnection();
+      PreparedStatement statement = connection.prepareStatement(
+        "SELECT path "
+          + "FROM url_index_store "
+          + "WHERE project_name = ? "
+          + "AND url = ?;\n")) {
+      statement.setString(1, projectName);
+      statement.setString(2, url);
+      try (ResultSet rs = statement.executeQuery()) {
+        if (rs.next()) {
+          String path = rs.getString(1);
+          return path;
+        } else {
+          return null;
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  };
+
+  @Override
+  public String getOldestUnswappedProject() {
+    try (
+      Connection connection = pool.getConnection();
+      Statement statement = connection.createStatement()) {
+      try (ResultSet rs = statement.executeQuery(
+          "SELECT name FROM projects" +
+            " ORDER BY last_accessed ASC" +
+            " LIMIT 1;\n")) {
+        if (rs.next()) {
+          String project = rs.getString(1);
+          return project;
+        } else {
+          return null;
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  };
+
+  @Override
+  public int getNumUnswappedProjects() {
+    try (
+      Connection connection = pool.getConnection();
+      Statement statement = connection.createStatement()) {
+      try (ResultSet rs = statement.executeQuery(
+          "SELECT COUNT(*)\n" +
+            " FROM projects\n" +
+            " WHERE last_accessed IS NOT NULL;\n")) {
+        if (rs.next()) {
+          int n = rs.getInt(1);
+          return n;
+        } else {
+          return 0;
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  };
+
+  @Override
+  public ProjectState getProjectState(String projectName) {
+    try (
+      Connection connection = pool.getConnection();
+      PreparedStatement statement = connection.prepareStatement(
+        "SELECT last_accessed\n" +
+          " FROM projects\n" +
+          " WHERE name = ?;\n")) {
+      statement.setString(1, projectName);
+      try (ResultSet rs = statement.executeQuery()) {
+        ProjectState result;
+        if (rs.next()) {
+          if (rs.getTimestamp(1) == null) {
+            result = ProjectState.SWAPPED;
+          } else {
+            result = ProjectState.PRESENT;
+          }
+        } else {
+          result = ProjectState.NOT_PRESENT;
+        }
+        return result;
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  };
+
+  @Override
+  public void setLastAccessedTime(String projectName, Timestamp time) {
+    try (
+      Connection connection = pool.getConnection();
+      PreparedStatement statement = connection.prepareStatement(
+        "UPDATE projects\n" +
+          "SET last_accessed = ?\n" +
+          "WHERE name = ?;\n"
+      )) {
+      statement.setTimestamp(1, time);
+      statement.setString(2, projectName);
+      statement.executeUpdate();
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  };
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresOptions.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresOptions.java
@@ -1,0 +1,64 @@
+package uk.ac.ic.wlgitbridge.bridge.db.postgres;
+
+public class PostgresOptions {
+
+  private String url;
+  private String username;
+  private String password;
+
+  // Connection Pool options
+  private int poolInitialSize;
+  private int poolMaxTotal;
+  private int poolMaxWaitMillis;
+
+  public PostgresOptions(
+    String url,
+    String username,
+    String password,
+    int initialSize,
+    int maxTotal,
+    int maxWaitMillis) {
+    this.url = url;
+    this.username = username;
+    this.password = password;
+    if (initialSize < 1) {
+      this.poolInitialSize = 1;
+    } else {
+      this.poolInitialSize = initialSize;
+    }
+    if (maxTotal < 1) {
+      this.poolMaxTotal = 1;
+    } else {
+      this.poolMaxTotal = maxTotal;
+    }
+    if (maxWaitMillis < 1) {
+      this.poolMaxWaitMillis = 1000;
+    } else {
+      this.poolMaxWaitMillis = maxWaitMillis;
+    }
+  }
+
+  public String getUrl() {
+    return this.url;
+  }
+
+  public String getUsername() {
+    return this.username;
+  }
+
+  public String getPassword() {
+    return this.password;
+  }
+
+  public int getPoolInitialSize() {
+      return this.poolInitialSize;
+  }
+
+  public int getPoolMaxTotal() {
+    return this.poolMaxTotal;
+  }
+
+  public int getPoolMaxWaitMillis() {
+    return this.poolMaxWaitMillis;
+  }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/SqliteConfig.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/SqliteConfig.java
@@ -1,0 +1,18 @@
+package uk.ac.ic.wlgitbridge.bridge.db.sqlite;
+
+import uk.ac.ic.wlgitbridge.bridge.db.DatabaseConfig;
+
+public class SqliteConfig implements DatabaseConfig {
+
+  public SqliteConfig() {};
+
+  @Override
+  public DatabaseType getDatabaseType() {
+    return DatabaseType.SQLite;
+  }
+
+  @Override
+  public DatabaseConfig asSanitized() {
+    return new SqliteConfig();
+  }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -10,7 +10,6 @@ import uk.ac.ic.wlgitbridge.application.config.Config;
 import uk.ac.ic.wlgitbridge.application.jetty.NullLogger;
 import uk.ac.ic.wlgitbridge.bridge.Bridge;
 import uk.ac.ic.wlgitbridge.bridge.db.DBStore;
-import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SqliteDBStore;
 import uk.ac.ic.wlgitbridge.bridge.repo.FSGitRepoStore;
 import uk.ac.ic.wlgitbridge.bridge.repo.RepoStore;
 import uk.ac.ic.wlgitbridge.bridge.repo.RepoStoreConfig;
@@ -25,10 +24,12 @@ import uk.ac.ic.wlgitbridge.util.Util;
 import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.ServletException;
+import javax.xml.crypto.Data;
 import java.io.File;
 import java.net.BindException;
 import java.nio.file.Paths;
 import java.util.EnumSet;
+import java.util.Optional;
 
 /**
  * Created by Winston on 02/11/14.
@@ -57,11 +58,7 @@ public class GitBridgeServer {
                 rootGitDirectoryPath,
                 config.getRepoStore().flatMap(RepoStoreConfig::getMaxFileSize)
         );
-        DBStore dbStore = new SqliteDBStore(
-                Paths.get(
-                        repoStore.getRootDirectory().getAbsolutePath()
-                ).resolve(".wlgb").resolve("wlgb.db").toFile()
-        );
+        DBStore dbStore = DBStore.fromConfig(config.getDatabase(), repoStore);
         SwapStore swapStore = SwapStore.fromConfig(config.getSwapStore());
         SnapshotApi snapshotApi = new NetSnapshotApi();
         bridge = Bridge.make(

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -19,22 +19,25 @@ import org.apache.http.ParseException;
 
 import org.asynchttpclient.*;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.rules.TemporaryFolder;
+import uk.ac.ic.wlgitbridge.bridge.db.DBInitException;
+import uk.ac.ic.wlgitbridge.bridge.db.postgres.PostgresDBStore;
 import uk.ac.ic.wlgitbridge.bridge.swap.job.SwapJobConfig;
 import uk.ac.ic.wlgitbridge.snapshot.servermock.server.MockSnapshotServer;
 import uk.ac.ic.wlgitbridge.snapshot.servermock.state.SnapshotAPIState;
 import uk.ac.ic.wlgitbridge.snapshot.servermock.state.SnapshotAPIStateBuilder;
 import uk.ac.ic.wlgitbridge.snapshot.servermock.util.FileUtil;
+import uk.ac.ic.wlgitbridge.util.Log;
 import uk.ac.ic.wlgitbridge.util.Util;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -159,10 +162,45 @@ public class WLGitBridgeIntegrationTest {
     private MockSnapshotServer server;
     private GitBridgeApp wlgb;
     private File dir;
+    // set env-var "TEST_DB_MODE", either "postgres" or "sqlite"
+    private static String databaseMode;
+    private Map<String, String> postgresConfig = new HashMap<String, String>() {{
+      put("url", "jdbc:postgresql://postgres_v2/gitbridge_test");
+      put("username", "sharelatex");
+      put("password", "sharelatex");
+    }};
+
+    private void resetPostgresDatabase() throws Exception {
+      try {
+        Class.forName("org.postgresql.Driver");
+        Connection connection = DriverManager
+          .getConnection(
+            postgresConfig.get("url"),
+            postgresConfig.get("username"),
+            postgresConfig.get("password")
+          );
+        Statement statement = connection.createStatement();
+        statement.execute("delete from url_index_store;");
+        statement.execute("delete from projects;");
+        statement.close();
+      } catch (Exception e) {
+        Log.error("Error connecting to Postgres: {}", e.getMessage());
+        throw e;
+      }
+    }
+
+  @BeforeClass
+    public static void before() throws Exception {
+      databaseMode = System.getenv("TEST_DB_MODE");
+      Log.info("Test database mode: " + databaseMode);
+    }
 
     @Before
     public void setUp() throws Exception {
-        dir = folder.newFolder();
+      dir = folder.newFolder();
+      if ("postgres".equals(databaseMode)) {
+        resetPostgresDatabase();
+      }
     }
 
     @After
@@ -1102,6 +1140,13 @@ public class WLGitBridgeIntegrationTest {
                     swapCfg.getIntervalMillis() +
                     "\n" +
                     "    }\n";
+        }
+        if ("postgres".equals(databaseMode)) {
+          cfgStr += ", \"database\": {\"type\": \"postgres\", " +
+            "\"options\": {\"url\": \"" + postgresConfig.get("url") + "\", " +
+            "\"username\": \""+ postgresConfig.get("username") +"\", " +
+            "\"password\": \""+ postgresConfig.get("password") +"\", " +
+            "\"poolInitialSize\": 2, \"poolMaxTotal\": 8, \"poolMaxWaitMillis\": 1000}}";
         }
         cfgStr += "}\n";
         writer.print(cfgStr);

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/config/ConfigTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/config/ConfigTest.java
@@ -98,8 +98,9 @@ public class ConfigTest {
                 "  },\n" +
                 "  \"repoStore\": null,\n" +
                 "  \"swapStore\": null,\n" +
-                "  \"swapJob\": null\n" +
-                "}";
+                "  \"swapJob\": null,\n" +
+                "  \"database\": null\n" +
+          "}";
         assertEquals(
                 "sanitised config did not hide sensitive fields",
                 expected,

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/BridgeTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/BridgeTest.java
@@ -63,6 +63,7 @@ public class BridgeTest {
                         null,
                         null,
                         null,
+                        null,
                         null),
                 lock,
                 repoStore,


### PR DESCRIPTION
Add PostgreSQL as a database option.

- Add postgres driver as a dependency
- Add an SQL file: `create-tables.sql`, used by the dev-environment to initialize the database
- Add a `PostgresDBStore` implementation of `DBStore` interface
- Add config option: `database`
  - When set to postgres, connect to Postgres, otherwise, use SQLite (the current implementation)
- Update the acceptance tests to allow for either Postgres or SQLite to be used
  - By setting and environment variable: `TEST_DB_MODE=postgres`
- Point the tests to a test database: `gitbridge_test`

Example of database config:

```json
    "database": {
      "type": "postgres",
      "options": {
        "url": "jdbc:postgresql://postgres_v2/gitbridge",
        "username": "sharelatex",
        "password": "sharelatex"
      }
    },
```

### Related PRs

- Dev Environment: https://github.com/overleaf/dev-environment/pull/408
- Part of https://github.com/overleaf/issues/issues/3676