### PR TITLE
Handle errors from the history service

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/io/http/ning/NingHttpClient.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/io/http/ning/NingHttpClient.java
@@ -52,11 +52,16 @@ public class NingHttpClient implements NingHttpClientFacade {
                 @Override
                 public byte[] onCompleted(
                         Response response
-                ) throws IOException {
+                ) throws Exception {
+                    int statusCode = response.getStatusCode();
+                    if (statusCode >= 400) {
+                        throw new Exception("got status " + statusCode +
+                                            " fetching " + url);
+                    }
                     byte[] ret = bytes.toByteArray();
                     bytes.close();
                     log.info(
-                            response.getStatusCode()
+                            statusCode
                                     + " "
                                     + response.getStatusText()
                                     + " ("


### PR DESCRIPTION
### Description

If the history service returns a non-success status code when we request a blob, chances are the payload is not the expected blob contents. We throw an exception in that case, which will abort the git operation.

#### Related Issues

Discovered while testing https://github.com/overleaf/web-internal/pull/3437

#### Screenshots

git pull when history returns an error:
```
$ git pull
fatal: remote error: Overleaf server not available. Please try again later.
```

Log entry in git-bridge:
```
2020-12-04 15:59:54.150 WARN  [qtp1820383114-22] GitBridgeApp: ExecutionException when fetching project: 5fac0543e1d666002645d54c, url: http://editor-api.overleaf.test:3100/api/projects/371/blobs/f4aa5aa57cf5fa79befc63ffdbcea910c5da1dfe?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0X2lkIjozNzEsImlhdCI6MTYwNzA5NzU5NCwiZXhwIjoxNjA3MDk5Mzk0fQ.3zmQkzzF5DRTOIgjNUO36_tuUss8oLOuwsnHN1WE5HEx&_path=sentry.jpg, 
path: sentry.jpg
java.util.concurrent.ExecutionException: java.lang.Exception: got status 401 fetching http://editor-api.overleaf.test:3100/api/projects/37
1/blobs/f4aa5aa57cf5fa79befc63ffdbcea910c5da1dfe?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwcm9qZWN0X2lkIjozNzEsImlhdCI6MTYwNzA5NzU5NCwiZXhwIjoxNjA3MDk5Mzk0fQ.3zmQkzzF5DRTOIgjNUO36_tuUss8oLOuwsnHN1WE5HEx&_path=sentry.jpg                                                 
        at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)                                                   
        at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)                                                                
        at org.asynchttpclient.netty.NettyResponseFuture.get(NettyResponseFuture.java:202)             
...
```

### Review

#### Potential impact

Hopefully, we were not ignoring too many errors. If that ever happened, a commit would be created in which the contents of the associated would be filled with the error response. For example:
```
{"message":"jwt missing","error":{"statusCode":401,"headers":{"WWW-Authenticate":"Bearer"},"code":"server_error"}}
```
However, this automatically recovers when the service is available again and the contents of the file is restored in a new commit.

#### Manual testing performed

Tested locally:
* [x] Make v1 history return an error and git pull (see Screenshots section above)
* [x] Fix v1 history and git pull again

