### PR TITLE
[misc] hide the download progress of dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,11 @@ run: package
 
 
 build:
-	mvn package -DskipTests
+	mvn --no-transfer-progress package -DskipTests
 
 
 test:
-	mvn test
+	mvn --no-transfer-progress test
 
 
 clean:
@@ -18,7 +18,7 @@ clean:
 
 
 package: clean
-	mvn package -DskipTests
+	mvn --no-transfer-progress package -DskipTests
 
 
 .PHONY: run package build clean test

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,25 @@
 # git-bridge makefile
 
+MVN_OPTS := "--no-transfer-progress"
 
 run: package
 	java -jar target/writelatex-git-bridge-1.0-SNAPSHOT-jar-with-dependencies.jar conf/local.json
 
 
 build:
-	mvn --no-transfer-progress package -DskipTests
+	mvn $(MVN_OPTS) package -DskipTests
 
 
 test:
-	mvn --no-transfer-progress test
+	mvn $(MVN_OPTS) test
 
 
 clean:
-	mvn clean
+	mvn $(MVN_OPTS) clean
 
 
 package: clean
-	mvn --no-transfer-progress package -DskipTests
+	mvn $(MVN_OPTS) package -DskipTests
 
 
 .PHONY: run package build clean test


### PR DESCRIPTION
Downloading artifacts via `mvn` is super verbose. This PR will silence the progress of downloads.

To be used by the new cloudbuild pipeline. The current pipeline is using `mvn` commands instead of `make` targets, so the changes are not visible yet, but tested locally.

<details>

```
dev-env$ rm .m2/repository/ -rf
dev-env$ bin/run git-bridge make build
mvn --no-transfer-progress package -DskipTests
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for uk.ac.ic.wlgitbridge:writelatex-git-bridge:jar:1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 28, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] 
[INFO] -------------< uk.ac.ic.wlgitbridge:writelatex-git-bridge >-------------
[INFO] Building writelatex-git-bridge 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ writelatex-git-bridge ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 1 resource
[INFO] 
[INFO] --- maven-compiler-plugin:3.7.0:compile (default-compile) @ writelatex-git-bridge ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ writelatex-git-bridge ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] Copying 336 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.7.0:testCompile (default-testCompile) @ writelatex-git-bridge ---
[INFO] Nothing to compile - all classes are up to date
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ writelatex-git-bridge ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ writelatex-git-bridge ---
[INFO] 
[INFO] --- maven-assembly-plugin:3.1.0:single (default) @ writelatex-git-bridge ---
[INFO] Building jar: /app/target/writelatex-git-bridge-1.0-SNAPSHOT-jar-with-dependencies.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:54 min
[INFO] Finished at: 2020-12-11T14:26:29Z
[INFO] ------------------------------------------------------------------------

dev-env$ du -h -d 0 .m2/repository/
189M    .m2/repository/
```
</details>