### PR TITLE
Use Postgres for row-based locking

### DIFF
--- a/conf/example_config.json
+++ b/conf/example_config.json
@@ -33,6 +33,17 @@
             "poolMaxWaitMillis": 20000
         }
     },
+    "database": {
+        "type": "postgres",
+        "options": {
+            "url": "jdbc:postgresql://postgres_v2/gitbridge",
+            "username": "sharelatex",
+            "password": "sharelatex",
+            "poolInitialSize": 2,
+            "poolMaxTotal": 8,
+            "poolMaxWaitMillis": 20000
+        }
+    },
     "swapJob": {
         "minProjects": 50,
         "lowGiB": 128,

--- a/create-tables.sql
+++ b/create-tables.sql
@@ -24,4 +24,9 @@ BEGIN;
     ON public.url_index_store
     USING btree
     (project_name, path);
+
+  CREATE TABLE IF NOT EXISTS public.project_locks (
+    "project_name" varchar(100) NOT NULL DEFAULT ''::character varying,
+    CONSTRAINT project_locks_pkey PRIMARY KEY (project_name)
+  );
 COMMIT;

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
@@ -378,34 +378,32 @@ public class Bridge {
             String migratedFromID = doc.getMigratedFromID();
             if (migratedFromID != null) {
                 Log.info("[{}] Has a migratedFromId: {}", projectName, migratedFromID);
-                try (LockGuard __ = lock.lockGuard(migratedFromID)) {
-                    ProjectState sourceState = dbStore.getProjectState(migratedFromID);
-                    switch (sourceState) {
-                        case NOT_PRESENT:
-                            // Normal init-repo
-                            Log.info("[{}] migrated-from project not present, proceed as normal",
-                                 projectName
-                            );
-                            repo = repoStore.initRepo(projectName);
-                            break;
-                        case SWAPPED:
-                            // Swap back and then copy
-                            swapJob.restore(migratedFromID);
-                            /* Fallthrough */
-                        default:
-                            // Copy data, and set version to zero
-                            Log.info("[{}] Init from other project: {}",
-                                projectName,
-                                migratedFromID
-                            );
-                            repo = repoStore.initRepoFromExisting(projectName, migratedFromID);
-                            dbStore.setLatestVersionForProject(migratedFromID, 0);
-                            dbStore.setLastAccessedTime(
-                                    migratedFromID,
-                                    Timestamp.valueOf(LocalDateTime.now())
+                ProjectState sourceState = dbStore.getProjectState(migratedFromID);
+                switch (sourceState) {
+                    case NOT_PRESENT:
+                        // Normal init-repo
+                        Log.info("[{}] migrated-from project not present, proceed as normal",
+                             projectName
+                        );
+                        repo = repoStore.initRepo(projectName);
+                        break;
+                    case SWAPPED:
+                        // Swap back and then copy
+                        swapJob.restore(migratedFromID);
+                        /* Fallthrough */
+                    default:
+                        // Copy data, and set version to zero
+                        Log.info("[{}] Init from other project: {}",
+                            projectName,
+                            migratedFromID
+                        );
+                        repo = repoStore.initRepoFromExisting(projectName, migratedFromID);
+                        dbStore.setLatestVersionForProject(migratedFromID, 0);
+                        dbStore.setLastAccessedTime(
+                                migratedFromID,
+                                Timestamp.valueOf(LocalDateTime.now())
 
-                            );
-                    }
+                        );
                 }
                 break;
             } else {

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
@@ -393,32 +393,34 @@ public class Bridge {
             String migratedFromID = doc.getMigratedFromID();
             if (migratedFromID != null) {
                 Log.info("[{}] Has a migratedFromId: {}", projectName, migratedFromID);
-                ProjectState sourceState = dbStore.getProjectState(migratedFromID);
-                switch (sourceState) {
-                    case NOT_PRESENT:
-                        // Normal init-repo
-                        Log.info("[{}] migrated-from project not present, proceed as normal",
-                             projectName
-                        );
-                        repo = repoStore.initRepo(projectName);
-                        break;
-                    case SWAPPED:
-                        // Swap back and then copy
-                        swapJob.restore(migratedFromID);
-                        /* Fallthrough */
-                    default:
-                        // Copy data, and set version to zero
-                        Log.info("[{}] Init from other project: {}",
-                            projectName,
-                            migratedFromID
-                        );
-                        repo = repoStore.initRepoFromExisting(projectName, migratedFromID);
-                        dbStore.setLatestVersionForProject(migratedFromID, 0);
-                        dbStore.setLastAccessedTime(
-                                migratedFromID,
-                                Timestamp.valueOf(LocalDateTime.now())
+                try (LockGuard __ = lock.lockGuard(migratedFromID)) {
+                    ProjectState sourceState = dbStore.getProjectState(migratedFromID);
+                    switch (sourceState) {
+                        case NOT_PRESENT:
+                            // Normal init-repo
+                            Log.info("[{}] migrated-from project not present, proceed as normal",
+                                 projectName
+                            );
+                            repo = repoStore.initRepo(projectName);
+                            break;
+                        case SWAPPED:
+                            // Swap back and then copy
+                            swapJob.restore(migratedFromID);
+                            /* Fallthrough */
+                        default:
+                            // Copy data, and set version to zero
+                            Log.info("[{}] Init from other project: {}",
+                                projectName,
+                                migratedFromID
+                            );
+                            repo = repoStore.initRepoFromExisting(projectName, migratedFromID);
+                            dbStore.setLatestVersionForProject(migratedFromID, 0);
+                            dbStore.setLastAccessedTime(
+                                    migratedFromID,
+                                    Timestamp.valueOf(LocalDateTime.now())
 
-                        );
+                            );
+                    }
                 }
                 break;
             } else {

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
@@ -243,7 +243,7 @@ public class Bridge {
      *
      * It is also used by the tests.
      */
-    void doShutdown() {
+    public void doShutdown() {
         Log.info("Shutdown received.");
         Log.info("Stopping SwapJob");
         swapJob.stop();
@@ -251,6 +251,8 @@ public class Bridge {
         gcJob.stop();
         Log.info("Waiting for projects");
         lock.lockAll();
+        Log.info("Closing database connections");
+        dbStore.close();
         Log.info("Bye");
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/Bridge.java
@@ -183,7 +183,7 @@ public class Bridge {
           config.getDatabase().get().getDatabaseType() == DatabaseConfig.DatabaseType.Postgres
         ) {
           Log.info("Using postgres lock implementation");
-          lock = new PostgresProjectLockImpl(((PostgresDBStore)dbStore), (int threads) ->
+          lock = new PostgresProjectLockImpl(((PostgresDBStore)dbStore).makeConnectionPool(), (int threads) ->
             Log.info("Waiting for " + threads + " projects...")
           );
         } else {
@@ -343,28 +343,14 @@ public class Bridge {
             Optional<Credential> oauth2,
             String projectName
     ) throws IOException, GitUserException {
-        try {
-            dbStore.prepareRequest();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
         try (LockGuard __ = lock.lockGuard(projectName)) {
-            // TODO: try/catch, and tell dbStore whether it should
-            //       commit or roll back when unlock is called?
-            try {
-                Optional<GetDocResult> maybeDoc = snapshotAPI.getDoc(oauth2, projectName);
-                if (!maybeDoc.isPresent()) {
-                    throw new RepositoryNotFoundException(projectName);
-                }
-                GetDocResult doc = maybeDoc.get();
-                Log.info("[{}] Updating repository", projectName);
-                ProjectRepo repo = getUpdatedRepoCritical(oauth2, projectName, doc);
-                dbStore.setRequestEnd("commit");
-                return repo;
-            } catch (Throwable t) {
-                dbStore.setRequestEnd("rollback");
-                throw t;
+            Optional<GetDocResult> maybeDoc = snapshotAPI.getDoc(oauth2, projectName);
+            if (!maybeDoc.isPresent()) {
+                throw new RepositoryNotFoundException(projectName);
             }
+            GetDocResult doc = maybeDoc.get();
+            Log.info("[{}] Updating repository", projectName);
+            return getUpdatedRepoCritical(oauth2, projectName, doc);
         }
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DBStore.java
@@ -41,6 +41,8 @@ public interface DBStore {
 
     int getNumUnswappedProjects();
 
+    void close();
+
     ProjectState getProjectState(String projectName);
 
     /**

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DBStore.java
@@ -8,7 +8,6 @@ import uk.ac.ic.wlgitbridge.bridge.repo.RepoStore;
 import uk.ac.ic.wlgitbridge.util.Log;
 
 import java.nio.file.Paths;
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
@@ -17,12 +16,6 @@ import java.util.Optional;
  * Created by winston on 20/08/2016.
  */
 public interface DBStore {
-
-    enum RequestEnd { Commit, Rollback };
-
-    void prepareRequest() throws SQLException;
-
-    void endRequest(RequestEnd end) throws SQLException;
 
     int getNumProjects();
 
@@ -47,8 +40,6 @@ public interface DBStore {
     String getSwapCompression(String projectName);
 
     int getNumUnswappedProjects();
-
-    void setRequestEnd(String end);
 
     void close();
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DBStore.java
@@ -8,6 +8,7 @@ import uk.ac.ic.wlgitbridge.bridge.repo.RepoStore;
 import uk.ac.ic.wlgitbridge.util.Log;
 
 import java.nio.file.Paths;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +17,12 @@ import java.util.Optional;
  * Created by winston on 20/08/2016.
  */
 public interface DBStore {
+
+    enum RequestEnd { Commit, Rollback };
+
+    void prepareRequest() throws SQLException;
+
+    void endRequest(RequestEnd end) throws SQLException;
 
     int getNumProjects();
 
@@ -40,6 +47,8 @@ public interface DBStore {
     String getSwapCompression(String projectName);
 
     int getNumUnswappedProjects();
+
+    void setRequestEnd(String end);
 
     void close();
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/noop/NoopDbStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/noop/NoopDbStore.java
@@ -3,7 +3,6 @@ package uk.ac.ic.wlgitbridge.bridge.db.noop;
 import uk.ac.ic.wlgitbridge.bridge.db.DBStore;
 import uk.ac.ic.wlgitbridge.bridge.db.ProjectState;
 
-import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
 
@@ -11,16 +10,6 @@ public class NoopDbStore implements DBStore {
 
     @Override
     public void close() { return; }
-
-    @Override
-    public void prepareRequest() throws SQLException {
-        return;
-    }
-
-    @Override
-    public void endRequest(RequestEnd end) throws SQLException {
-        return;
-    }
 
     @Override
     public int getNumProjects() {
@@ -65,11 +54,6 @@ public class NoopDbStore implements DBStore {
     @Override
     public int getNumUnswappedProjects() {
         return 0;
-    }
-
-    @Override
-    public void setRequestEnd(String end) {
-        return;
     }
 
     @Override

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/noop/NoopDbStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/noop/NoopDbStore.java
@@ -3,6 +3,7 @@ package uk.ac.ic.wlgitbridge.bridge.db.noop;
 import uk.ac.ic.wlgitbridge.bridge.db.DBStore;
 import uk.ac.ic.wlgitbridge.bridge.db.ProjectState;
 
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
 
@@ -10,6 +11,16 @@ public class NoopDbStore implements DBStore {
 
     @Override
     public void close() { return; }
+
+    @Override
+    public void prepareRequest() throws SQLException {
+        return;
+    }
+
+    @Override
+    public void endRequest(RequestEnd end) throws SQLException {
+        return;
+    }
 
     @Override
     public int getNumProjects() {
@@ -54,6 +65,11 @@ public class NoopDbStore implements DBStore {
     @Override
     public int getNumUnswappedProjects() {
         return 0;
+    }
+
+    @Override
+    public void setRequestEnd(String end) {
+        return;
     }
 
     @Override

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/noop/NoopDbStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/noop/NoopDbStore.java
@@ -9,6 +9,9 @@ import java.util.List;
 public class NoopDbStore implements DBStore {
 
     @Override
+    public void close() { return; }
+
+    @Override
     public int getNumProjects() {
         return 0;
     }

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresDBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresDBStore.java
@@ -15,6 +15,8 @@ public class PostgresDBStore implements DBStore {
 
   private final PostgresOptions options;
   private final BasicDataSource pool;
+  private ThreadLocal<Connection> connectionBox = new ThreadLocal();
+  private ThreadLocal<RequestEnd> requestEndBox = new ThreadLocal();
 
   public PostgresDBStore(PostgresOptions postgresOptions) {
     options = postgresOptions;
@@ -27,6 +29,7 @@ public class PostgresDBStore implements DBStore {
     }
   }
 
+  // TODO: make private
   public BasicDataSource makeConnectionPool() {
     BasicDataSource dataSource = new BasicDataSource();
     dataSource.setDriverClassName("org.postgresql.Driver");
@@ -49,6 +52,43 @@ public class PostgresDBStore implements DBStore {
   }
 
   @Override
+  public synchronized void prepareRequest() throws SQLException {
+    Log.info("Preparing database for request");
+    // TODO:
+    //   - turn off autocommit
+    //   - start transaction
+    Connection conn = pool.getConnection();
+    conn.setAutoCommit(true);
+    try (Statement statement = conn.createStatement()) {
+      statement.execute("set lock_timeout to 59999;");
+    }
+    conn.setAutoCommit(false);
+    connectionBox.set(conn);
+    requestEndBox.set(null);
+  }
+
+  // TODO: should we commit or rollback?
+  @Override
+  public synchronized void endRequest(RequestEnd end) throws SQLException {
+    Log.info("Ending request on database");
+    Connection conn = connectionBox.get();
+    if (end == RequestEnd.Commit) {
+      conn.commit();
+    } else if (end == RequestEnd.Rollback) {
+      conn.rollback();
+    }
+    conn.close();
+  }
+
+  private Connection getConnection() {
+    Connection connection = connectionBox.get();
+    if (connection == null) {
+      throw new RuntimeException("Tried to get connection, but not initialized");
+    }
+    return connectionBox.get();
+  }
+
+  @Override
   public void close() {
     try {
       pool.close();
@@ -59,9 +99,9 @@ public class PostgresDBStore implements DBStore {
   }
 
   @Override
-  public int getNumProjects() {
+  public synchronized int getNumProjects() {
     try (
-      Connection connection = pool.getConnection();
+      Connection connection = getConnection();
       Statement statement = connection.createStatement();
          ResultSet rs = statement.executeQuery("SELECT count(*) from projects;\n")) {
       if (rs.next()) {
@@ -76,9 +116,9 @@ public class PostgresDBStore implements DBStore {
   };
 
   @Override
-  public List<String> getProjectNames() {
+  public synchronized List<String> getProjectNames() {
     try (
-      Connection connection = pool.getConnection();
+      Connection connection = getConnection();
       Statement statement = connection.createStatement();
          ResultSet rs = statement.executeQuery("SELECT name from projects;\n")) {
       List<String> result = new ArrayList<String>();
@@ -92,9 +132,9 @@ public class PostgresDBStore implements DBStore {
   };
 
   @Override
-  public void setLatestVersionForProject(String project, int versionID) {
+  public synchronized void setLatestVersionForProject(String project, int versionID) {
     try (
-      Connection connection = pool.getConnection();
+      Connection connection = getConnection();
       PreparedStatement statement = connection.prepareStatement(
         "INSERT INTO "
            + "projects (name, version_id, last_accessed) "
@@ -110,9 +150,9 @@ public class PostgresDBStore implements DBStore {
   };
 
   @Override
-  public int getLatestVersionForProject(String project) {
+  public synchronized int getLatestVersionForProject(String project) {
     try (
-      Connection connection = pool.getConnection();
+      Connection connection = getConnection();
       PreparedStatement statement = connection.prepareStatement(
         "SELECT version_id from projects where name = ?;")) {
       statement.setString(1, project);
@@ -130,9 +170,9 @@ public class PostgresDBStore implements DBStore {
   };
 
   @Override
-  public void addURLIndexForProject(String projectName, String url, String path) {
+  public synchronized void addURLIndexForProject(String projectName, String url, String path) {
     try (
-      Connection connection = pool.getConnection();
+      Connection connection = getConnection();
       PreparedStatement statement = connection.prepareStatement(
       "INSERT INTO url_index_store(" +
          "project_name, " +
@@ -152,7 +192,7 @@ public class PostgresDBStore implements DBStore {
   };
 
   @Override
-  public void deleteFilesForProject(String project, String... files) {
+  public synchronized void deleteFilesForProject(String project, String... files) {
     if (files.length == 0) {
       return;
     }
@@ -167,7 +207,7 @@ public class PostgresDBStore implements DBStore {
     }
     queryBuilder.append(");\n");
     try (
-      Connection connection = pool.getConnection();
+      Connection connection = getConnection();
       PreparedStatement statement = connection.prepareStatement(queryBuilder.toString())) {
       statement.setString(1, project);
       for (int i = 0; i < files.length; i++) {
@@ -180,9 +220,9 @@ public class PostgresDBStore implements DBStore {
   };
 
   @Override
-  public String getPathForURLInProject(String projectName, String url) {
+  public synchronized String getPathForURLInProject(String projectName, String url) {
     try (
-      Connection connection = pool.getConnection();
+      Connection connection = getConnection();
       PreparedStatement statement = connection.prepareStatement(
         "SELECT path "
           + "FROM url_index_store "
@@ -204,9 +244,9 @@ public class PostgresDBStore implements DBStore {
   };
 
   @Override
-  public String getOldestUnswappedProject() {
+  public synchronized String getOldestUnswappedProject() {
     try (
-      Connection connection = pool.getConnection();
+      Connection connection = getConnection();
       Statement statement = connection.createStatement()) {
       try (ResultSet rs = statement.executeQuery(
           "SELECT name FROM projects" +
@@ -225,9 +265,9 @@ public class PostgresDBStore implements DBStore {
   };
 
   @Override
-  public int getNumUnswappedProjects() {
+  public synchronized int getNumUnswappedProjects() {
     try (
-      Connection connection = pool.getConnection();
+      Connection connection = getConnection();
       Statement statement = connection.createStatement()) {
       try (ResultSet rs = statement.executeQuery(
           "SELECT COUNT(*)\n" +
@@ -246,9 +286,9 @@ public class PostgresDBStore implements DBStore {
   };
 
   @Override
-  public ProjectState getProjectState(String projectName) {
+  public synchronized ProjectState getProjectState(String projectName) {
     try (
-      Connection connection = pool.getConnection();
+      Connection connection = getConnection();
       PreparedStatement statement = connection.prepareStatement(
         "SELECT last_accessed\n" +
           " FROM projects\n" +
@@ -273,9 +313,9 @@ public class PostgresDBStore implements DBStore {
   };
 
   @Override
-  public void setLastAccessedTime(String projectName, Timestamp time) {
+  public synchronized void setLastAccessedTime(String projectName, Timestamp time) {
     try (
-      Connection connection = pool.getConnection();
+      Connection connection = getConnection();
       PreparedStatement statement = connection.prepareStatement(
         "UPDATE projects\n" +
           "SET last_accessed = ?\n" +
@@ -347,6 +387,68 @@ public class PostgresDBStore implements DBStore {
       }
     } catch (Exception e) {
       throw new RuntimeException("Postgres query error", e);
+    }
+  }
+
+  public synchronized void takeLock(String projectName) {
+    Connection connection = getConnection();
+    try {
+      connection.setAutoCommit(true);
+      try (
+              PreparedStatement statement = connection.prepareStatement(
+                      "INSERT into projects (name, version_id) values (?, 0) ON CONFLICT DO NOTHING;"
+              )
+      ) {
+        statement.setString(1, projectName);
+        statement.execute();
+      }
+      try (Statement statement = connection.createStatement()) {
+        statement.execute("set lock_timeout to 59999;");
+      }
+      connection.setAutoCommit(false);
+      try (
+              PreparedStatement statement = connection.prepareStatement(
+                      "SELECT * from project" +
+                              " WHERE name = ?" +
+                              " FOR UPDATE;"
+              );
+      ) {
+        statement.setString(1, projectName);
+        statement.executeQuery();
+      }
+      return;
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error while locking " + projectName, e);
+    }
+  }
+
+  public synchronized void releaseLock(String projectName) {
+    RequestEnd requestEnd = requestEndBox.get();
+    Connection connection = getConnection();
+    try {
+      if (requestEnd == RequestEnd.Commit) {
+        connection.commit();
+      } else if (requestEnd == RequestEnd.Rollback) {
+        connection.rollback();
+      } else {
+        throw new RuntimeException("[{}] Invalid request end: " + requestEnd.toString());
+      }
+      connection.setAutoCommit(true);
+      connection.close();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // TODO: not a string
+  @Override
+  public void setRequestEnd(String end) {
+    if ("commit".equals(end)) {
+      requestEndBox.set(RequestEnd.Commit);
+    } else if ("rollback".equals(end)) {
+      requestEndBox.set(RequestEnd.Rollback);
+    } else {
+      throw new RuntimeException("invalid request end: " + end);
     }
   }
 }

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresDBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresDBStore.java
@@ -13,32 +13,39 @@ import java.util.List;
 
 public class PostgresDBStore implements DBStore {
 
+  private final PostgresOptions options;
   private final BasicDataSource pool;
 
-  public PostgresDBStore(PostgresOptions options) {
+  public PostgresDBStore(PostgresOptions postgresOptions) {
+    options = postgresOptions;
     Log.info("Initialize PostgresDBStore");
     try {
-      pool = new BasicDataSource();
-      pool.setDriverClassName("org.postgresql.Driver");
-      pool.setUrl(options.getUrl());
-      pool.setUsername(options.getUsername());
-      pool.setPassword(options.getPassword());
-      int poolInitialSize = options.getPoolInitialSize();
-      int poolMaxTotal = options.getPoolMaxTotal();
-      int poolMaxWaitMillis = options.getPoolMaxWaitMillis();
-      if (poolInitialSize < 1) {
-        throw new RuntimeException("Invalid poolInitialSize: " + poolInitialSize);
-      }
-      if (poolMaxTotal < poolInitialSize) {
-        throw new RuntimeException("Invalid poolMaxTotal and poolInitialSize: " + poolMaxTotal + ", " + poolInitialSize);
-      }
-      pool.setInitialSize(poolInitialSize);
-      pool.setMaxTotal(poolMaxTotal);
-      pool.setMaxWaitMillis(poolMaxWaitMillis);
+      pool = makeConnectionPool();
     } catch (Exception e) {
       Log.error("Error connecting to Postgres: {}", e.getMessage());
       throw new DBInitException(e);
     }
+  }
+
+  public BasicDataSource makeConnectionPool() {
+    BasicDataSource dataSource = new BasicDataSource();
+    dataSource.setDriverClassName("org.postgresql.Driver");
+    dataSource.setUrl(options.getUrl());
+    dataSource.setUsername(options.getUsername());
+    dataSource.setPassword(options.getPassword());
+    int poolInitialSize = options.getPoolInitialSize();
+    int poolMaxTotal = options.getPoolMaxTotal();
+    int poolMaxWaitMillis = options.getPoolMaxWaitMillis();
+    if (poolInitialSize < 1) {
+      throw new RuntimeException("Invalid poolInitialSize: " + poolInitialSize);
+    }
+    if (poolMaxTotal < poolInitialSize) {
+      throw new RuntimeException("Invalid poolMaxTotal and poolInitialSize: " + poolMaxTotal + ", " + poolInitialSize);
+    }
+    dataSource.setInitialSize(poolInitialSize);
+    dataSource.setMaxTotal(poolMaxTotal);
+    dataSource.setMaxWaitMillis(poolMaxWaitMillis);
+    return dataSource;
   }
 
   @Override

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresDBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresDBStore.java
@@ -42,6 +42,16 @@ public class PostgresDBStore implements DBStore {
   }
 
   @Override
+  public void close() {
+    try {
+      pool.close();
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres error while closing", e);
+    }
+    return;
+  }
+
+  @Override
   public int getNumProjects() {
     try (
       Connection connection = pool.getConnection();

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresRowLock.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresRowLock.java
@@ -1,0 +1,88 @@
+package uk.ac.ic.wlgitbridge.bridge.db.postgres;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.Statement;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+
+public class PostgresRowLock implements Lock {
+
+  private String projectName;
+  private Connection connection;
+  private boolean isLocking = false;
+
+  public PostgresRowLock(String projectName, Connection conn) {
+    this.projectName = projectName;
+    this.connection = conn;
+  }
+
+  @Override
+  public void lock() {
+    try {
+      connection.setAutoCommit(true);
+      try (
+        PreparedStatement statement = this.connection.prepareStatement(
+          "INSERT into project_locks (project_name) values (?) ON CONFLICT DO NOTHING;"
+        )
+      ) {
+        statement.setString(1, this.projectName);
+        statement.execute();
+      }
+      try (Statement statement = this.connection.createStatement()) {
+        statement.execute("set lock_timeout to 59999;");
+      }
+      this.connection.setAutoCommit(false);
+      this.isLocking = true;
+      try (
+        PreparedStatement statement = this.connection.prepareStatement(
+          "SELECT * from project_locks" +
+            " WHERE project_name = ?" +
+            " FOR UPDATE;"
+        );
+        ) {
+        statement.setString(1, this.projectName);
+        statement.executeQuery();
+      }
+      return;
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error while locking " + this.projectName, e);
+    }
+  }
+
+  @Override
+  public void unlock() {
+    if (!this.isLocking) {
+      throw new RuntimeException("unlock called, but lock is not taken");
+    }
+    try {
+      this.connection.commit();
+      this.connection.setAutoCommit(true);
+      this.connection.close();
+      return;
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  }
+
+  @Override
+  public void lockInterruptibly() throws InterruptedException {
+    throw new InterruptedException("not possible");
+  }
+
+  @Override
+  public boolean tryLock() {
+    return false;
+  }
+
+  @Override
+  public boolean tryLock(long l, TimeUnit timeUnit) throws InterruptedException {
+    return false;
+  }
+
+  @Override
+  public Condition newCondition() {
+    return null;
+  }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresRowLock.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/postgres/PostgresRowLock.java
@@ -10,19 +10,42 @@ import java.util.concurrent.locks.Lock;
 public class PostgresRowLock implements Lock {
 
   private String projectName;
-  private PostgresDBStore dbStore;
+  private Connection connection;
   private boolean isLocking = false;
 
-  public PostgresRowLock(String projectName, PostgresDBStore dbStore) {
+  public PostgresRowLock(String projectName, Connection conn) {
     this.projectName = projectName;
-    this.dbStore = dbStore;
+    this.connection = conn;
   }
 
   @Override
   public void lock() {
     try {
-      dbStore.takeLock(projectName);
+      connection.setAutoCommit(true);
+      try (
+        PreparedStatement statement = this.connection.prepareStatement(
+          "INSERT into project_locks (project_name) values (?) ON CONFLICT DO NOTHING;"
+        )
+      ) {
+        statement.setString(1, this.projectName);
+        statement.execute();
+      }
+      try (Statement statement = this.connection.createStatement()) {
+        statement.execute("set lock_timeout to 59999;");
+      }
+      this.connection.setAutoCommit(false);
       this.isLocking = true;
+      try (
+        PreparedStatement statement = this.connection.prepareStatement(
+          "SELECT * from project_locks" +
+            " WHERE project_name = ?" +
+            " FOR UPDATE;"
+        );
+        ) {
+        statement.setString(1, this.projectName);
+        statement.executeQuery();
+      }
+      return;
     } catch (Exception e) {
       throw new RuntimeException("Postgres query error while locking " + this.projectName, e);
     }
@@ -34,9 +57,12 @@ public class PostgresRowLock implements Lock {
       throw new RuntimeException("unlock called, but lock is not taken");
     }
     try {
-      dbStore.releaseLock(projectName);
+      this.connection.commit();
+      this.connection.setAutoCommit(true);
+      this.connection.close();
+      return;
     } catch (Exception e) {
-      throw new RuntimeException("Postgres query error while releasing lock", e);
+      throw new RuntimeException("Postgres query error", e);
     }
   }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/SqliteDBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/SqliteDBStore.java
@@ -32,6 +32,16 @@ public class SqliteDBStore implements DBStore {
     }
 
     @Override
+    public void prepareRequest() throws SQLException {
+        return;
+    }
+
+    @Override
+    public void endRequest(RequestEnd end) throws SQLException {
+        return;
+    }
+
+    @Override
     public void close() {
       return;
     }
@@ -94,6 +104,11 @@ public class SqliteDBStore implements DBStore {
     @Override
     public int getNumUnswappedProjects() {
         return query(new GetNumUnswappedProjects());
+    }
+
+    @Override
+    public void setRequestEnd(String end) {
+        return;
     }
 
     @Override

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/SqliteDBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/SqliteDBStore.java
@@ -32,6 +32,11 @@ public class SqliteDBStore implements DBStore {
     }
 
     @Override
+    public void close() {
+      return;
+    }
+
+    @Override
     public int getNumProjects() {
         return query(new GetNumProjects());
     }

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/SqliteDBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/SqliteDBStore.java
@@ -32,16 +32,6 @@ public class SqliteDBStore implements DBStore {
     }
 
     @Override
-    public void prepareRequest() throws SQLException {
-        return;
-    }
-
-    @Override
-    public void endRequest(RequestEnd end) throws SQLException {
-        return;
-    }
-
-    @Override
     public void close() {
       return;
     }
@@ -104,11 +94,6 @@ public class SqliteDBStore implements DBStore {
     @Override
     public int getNumUnswappedProjects() {
         return query(new GetNumUnswappedProjects());
-    }
-
-    @Override
-    public void setRequestEnd(String end) {
-        return;
     }
 
     @Override

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImpl.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImpl.java
@@ -236,26 +236,24 @@ public class SwapJobImpl implements SwapJob {
      */
     @Override
     public void restore(String projName) throws IOException {
-        try (LockGuard __ = lock.lockGuard(projName)) {
-            try (InputStream zipped = swapStore.openDownloadStream(projName)) {
-                String compression = dbStore.getSwapCompression(projName);
-                if (compression == null) {
-                    throw new RuntimeException("Missing compression method during restore, should not happen");
-                }
-                if ("gzip".equals(compression)) {
-                  repoStore.ungzipProject(
-                    projName,
-                    zipped
-                  );
-                } else if ("bzip2".equals(compression)) {
-                  repoStore.unbzip2Project(
-                    projName,
-                    zipped
-                  );
-                }
-                swapStore.remove(projName);
-                dbStore.restore(projName);
+        try (InputStream zipped = swapStore.openDownloadStream(projName)) {
+            String compression = dbStore.getSwapCompression(projName);
+            if (compression == null) {
+                throw new RuntimeException("Missing compression method during restore, should not happen");
             }
+            if ("gzip".equals(compression)) {
+              repoStore.ungzipProject(
+                projName,
+                zipped
+              );
+            } else if ("bzip2".equals(compression)) {
+              repoStore.unbzip2Project(
+                projName,
+                zipped
+              );
+            }
+            swapStore.remove(projName);
+            dbStore.restore(projName);
         }
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImpl.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImpl.java
@@ -236,24 +236,26 @@ public class SwapJobImpl implements SwapJob {
      */
     @Override
     public void restore(String projName) throws IOException {
-        try (InputStream zipped = swapStore.openDownloadStream(projName)) {
-            String compression = dbStore.getSwapCompression(projName);
-            if (compression == null) {
-                throw new RuntimeException("Missing compression method during restore, should not happen");
+        try (LockGuard __ = lock.lockGuard(projName)) {
+            try (InputStream zipped = swapStore.openDownloadStream(projName)) {
+                String compression = dbStore.getSwapCompression(projName);
+                if (compression == null) {
+                    throw new RuntimeException("Missing compression method during restore, should not happen");
+                }
+                if ("gzip".equals(compression)) {
+                  repoStore.ungzipProject(
+                    projName,
+                    zipped
+                  );
+                } else if ("bzip2".equals(compression)) {
+                  repoStore.unbzip2Project(
+                    projName,
+                    zipped
+                  );
+                }
+                swapStore.remove(projName);
+                dbStore.restore(projName);
             }
-            if ("gzip".equals(compression)) {
-              repoStore.ungzipProject(
-                projName,
-                zipped
-              );
-            } else if ("bzip2".equals(compression)) {
-              repoStore.unbzip2Project(
-                projName,
-                zipped
-              );
-            }
-            swapStore.remove(projName);
-            dbStore.restore(projName);
         }
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/data/PostgresProjectLockImpl.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/PostgresProjectLockImpl.java
@@ -57,21 +57,33 @@ public class PostgresProjectLockImpl implements ProjectLock {
     return getProjectLock(projectName);
   }
 
+  private synchronized void storeLock(String projectName, Lock lock) {
+    projectLocks.put(projectName, lock);
+  }
+
+  private synchronized Lock retrieveLock(String projectName) {
+    return projectLocks.get(projectName);
+  }
+
+  private synchronized void removeLock(String projectName) {
+    projectLocks.remove(projectName);
+  }
+
   @Override
   public void lockForProject(String projectName) {
     rlock.lock();
     Lock lock = getLockForProjectName(projectName);
     lock.lock();
-    projectLocks.put(projectName, lock);
+    storeLock(projectName, lock);
   }
 
   @Override
   public void unlockForProject(String projectName) {
-    Lock lock = projectLocks.get(projectName);
+    Lock lock = retrieveLock(projectName);
     if (lock == null) {
       return;
     }
-    projectLocks.remove(projectName);
+    removeLock(projectName);
     lock.unlock();
     rlock.unlock();
     if (waiting) {

--- a/src/main/java/uk/ac/ic/wlgitbridge/data/PostgresProjectLockImpl.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/PostgresProjectLockImpl.java
@@ -1,0 +1,106 @@
+package uk.ac.ic.wlgitbridge.data;
+
+import org.apache.commons.dbcp2.BasicDataSource;
+import uk.ac.ic.wlgitbridge.bridge.db.postgres.PostgresRowLock;
+import uk.ac.ic.wlgitbridge.bridge.lock.ProjectLock;
+
+import java.sql.Connection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class PostgresProjectLockImpl implements ProjectLock {
+
+  // Keep locks in a map, for lookup by name
+  private final Map<String, Lock> projectLocks;
+
+  // An app-level lock that tracks all current "operations", or,
+  // threads that currently hold a lock. This allows us to wait on
+  // the wlock, effectively waiting for all outstanding operations to
+  // complete, before shutting down
+  private final ReentrantReadWriteLock rwlock;
+  private final Lock rlock;
+  private final ReentrantReadWriteLock.WriteLock wlock;
+
+  // Postgres connection pool
+  private final BasicDataSource pool;
+
+  private LockAllWaiter waiter;
+  private boolean waiting;
+
+  public PostgresProjectLockImpl(BasicDataSource connectionPool) {
+    projectLocks = new HashMap<String, Lock>();
+    rwlock = new ReentrantReadWriteLock();
+    rlock = rwlock.readLock();
+    wlock = rwlock.writeLock();
+    pool = connectionPool;
+    waiting = false;
+  }
+
+  public PostgresProjectLockImpl(BasicDataSource connectionPool, LockAllWaiter waiter) {
+    this(connectionPool);
+    setWaiter(waiter);
+  }
+
+  private PostgresRowLock getProjectLock(String projectName) {
+    try {
+      Connection connection = pool.getConnection();
+      PostgresRowLock lock = new PostgresRowLock(projectName, connection);
+      return lock;
+    } catch (Exception e) {
+      throw new RuntimeException("Postgres query error", e);
+    }
+  }
+
+  private synchronized Lock getLockForProjectName(String projectName) {
+    return getProjectLock(projectName);
+  }
+
+  @Override
+  public void lockForProject(String projectName) {
+    rlock.lock();
+    Lock lock = getLockForProjectName(projectName);
+    lock.lock();
+    projectLocks.put(projectName, lock);
+  }
+
+  @Override
+  public void unlockForProject(String projectName) {
+    Lock lock = projectLocks.get(projectName);
+    if (lock == null) {
+      return;
+    }
+    projectLocks.remove(projectName);
+    lock.unlock();
+    rlock.unlock();
+    if (waiting) {
+      trySignal();
+    }
+  }
+
+  private void trySignal() {
+    int threads = rwlock.getReadLockCount();
+    if (waiter != null && threads > 0) {
+      waiter.threadsRemaining(threads);
+    }
+  }
+
+  // lock the wlock, preventing any more threads from
+  // getting the rlock (to start work). Used when stopping
+  // the server
+  public void lockAll() {
+    waiting = true;
+    trySignal();
+    wlock.lock();
+    try {
+      pool.close();
+    } catch (Exception e) {
+      throw new RuntimeException(e); // TODO: better log
+    }
+  }
+
+  public void setWaiter(LockAllWaiter waiter) {
+    this.waiter = waiter;
+  }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/data/PostgresProjectLockImpl.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/PostgresProjectLockImpl.java
@@ -80,11 +80,10 @@ public class PostgresProjectLockImpl implements ProjectLock {
   @Override
   public void unlockForProject(String projectName) {
     Lock lock = retrieveLock(projectName);
-    if (lock == null) {
-      return;
+    if (lock != null) {
+      lock.unlock();
+      removeLock(projectName);
     }
-    removeLock(projectName);
-    lock.unlock();
     activityLock.unlock();
     if (waiting) {
       trySignal();

--- a/src/main/java/uk/ac/ic/wlgitbridge/data/ProjectLockImpl.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/data/ProjectLockImpl.java
@@ -35,8 +35,8 @@ public class ProjectLockImpl implements ProjectLock {
 
     @Override
     public void lockForProject(String projectName) {
-        getLockForProjectName(projectName).lock();
         rlock.lock();
+        getLockForProjectName(projectName).lock();
     }
 
     @Override

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -104,6 +104,7 @@ public class GitBridgeServer {
     public void stop() {
         try {
             jettyServer.stop();
+            bridge.doShutdown();
         } catch (Exception e) {
             Log.error("Failed to stop Jetty", e);
         }

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -182,6 +182,7 @@ public class WLGitBridgeIntegrationTest {
         Statement statement = connection.createStatement();
         statement.execute("delete from url_index_store;");
         statement.execute("delete from projects;");
+        statement.execute("delete from project_locks;");
         statement.close();
       } catch (Exception e) {
         Log.error("Error connecting to Postgres: {}", e.getMessage());

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -724,18 +724,18 @@ public class WLGitBridgeIntegrationTest {
         File rootGitDir = new File(wlgb.config.getRootGitDirectory());
         File testProj1ServerDir = new File(rootGitDir, "testproj1");
         File testProj2ServerDir = new File(rootGitDir, "testproj2");
-        File testProj1Dir = gitClone("testproj1", 33874, dir);
+        File testProj1Dir = gitClone("testproj1", 33874, dir);   // clone 1
         assertTrue(testProj1ServerDir.exists());
         assertFalse(testProj2ServerDir.exists());
-        gitClone("testproj2", 33874, dir);
-        while (testProj1ServerDir.exists());
+        gitClone("testproj2", 33874, dir);                       // clone 2
+        while (testProj1ServerDir.exists());                     // wait for 1 to disappear (swap)
         assertFalse(testProj1ServerDir.exists());
-        assertTrue(testProj2ServerDir.exists());
+        assertTrue(testProj2ServerDir.exists());                 // only 1 exists
         FileUtils.deleteDirectory(testProj1Dir);
-        gitClone("testproj1", 33874, dir);
-        while (testProj2ServerDir.exists());
+        gitClone("testproj1", 33874, dir);                       // clone 1
+        while (testProj2ServerDir.exists());                     // wait for 2 to disappear (swap)
         assertTrue(testProj1ServerDir.exists());
-        assertFalse(testProj2ServerDir.exists());
+        assertFalse(testProj2ServerDir.exists());                // only 2 exists
     }
 
     private static final List<String> EXPECTED_OUT_PUSH_SUBMODULE = Arrays.asList(

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -21,6 +21,7 @@ import org.asynchttpclient.*;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runners.MethodSorters;
 import uk.ac.ic.wlgitbridge.bridge.db.DBInitException;
 import uk.ac.ic.wlgitbridge.bridge.db.postgres.PostgresDBStore;
 import uk.ac.ic.wlgitbridge.bridge.swap.job.SwapJobConfig;
@@ -49,6 +50,8 @@ import static org.junit.Assert.*;
 /**
  * Created by Winston on 11/01/15.
  */
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class WLGitBridgeIntegrationTest {
 
     private Runtime runtime = Runtime.getRuntime();

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -1159,7 +1159,7 @@ public class WLGitBridgeIntegrationTest {
             "\"options\": {\"url\": \"" + postgresConfig.get("url") + "\", " +
             "\"username\": \""+ postgresConfig.get("username") +"\", " +
             "\"password\": \""+ postgresConfig.get("password") +"\", " +
-            "\"poolInitialSize\": 2, \"poolMaxTotal\": 8, \"poolMaxWaitMillis\": 1000}}";
+            "\"poolInitialSize\": 4, \"poolMaxTotal\": 8, \"poolMaxWaitMillis\": 1000}}";
         }
         cfgStr += "}\n";
         writer.print(cfgStr);


### PR DESCRIPTION
## Description

This PR adds a locking implementation that uses Postgres row locks. 
In addition, we clean up some of the automated test infrastructure to avoid overwhelming Postgres with connections.

(Note: I intend to do another sweep to check for faults, but I think this is ready for an initial review)

## How it works

- Add a new table: `project_locks`
- When the application is configured to use postgres, use `PostgresProjectLockImpl` instedd of the default lock system.
  - Each project lock is an instance of `PostgresRowLock`, which wraps an open connection to Postgres. 
  - The connection performs a `SELECT FOR UPDATE` query, in an open transaction, locking the relevant row in the `project_locks` table. (See [docs](https://www.postgresql.org/docs/current/explicit-locking.html))
  - When the `PostgresRowLock` is released, the transaction commits, releasing the lock on the table row

Assorted other changes:

- Removed redundant attempts to acquire the project lock. The old implementation was tolerant of "double dipping" on locks, so long as the same thread tied to acquire the lock again. We can't work with this in the Postgres implementation, so we ensure that the lock is acquired once at the "top" of the logic, and not acquired again.
- There are now _two_ Postgres connection pools, one for the regular Postgres data store, and one for the Postgres lock system. The reason for this is that with a single pool it is possible to exhaust the pool on open locks, with no connections remaining to do the work that could lead to a lock being released.
- When the server shuts down, we close both connection pools
  - This is especially important in the automated tests, as they can rapidly exhaust the connection capacity of the Postgres server


## Related Issues/PRs

- Closes https://github.com/overleaf/issues/issues/3677
- Based on Postgres feature added in https://github.com/overleaf/issues/issues/3676
- Part of https://github.com/overleaf/issues/issues/3558