### PR TITLE
Gzip Compression in Swap Job

### DIFF
--- a/conf/example_config.json
+++ b/conf/example_config.json
@@ -26,6 +26,7 @@
         "minProjects": 50,
         "lowGiB": 128,
         "highGiB": 256,
-        "intervalMillis": 3600000
+        "intervalMillis": 3600000,
+        "compressionMethod": "bzip2"
     }
 }

--- a/conf/example_config.json
+++ b/conf/example_config.json
@@ -27,6 +27,6 @@
         "lowGiB": 128,
         "highGiB": 256,
         "intervalMillis": 3600000,
-        "compressionMethod": "bzip2"
+        "compressionMethod": "gzip"
     }
 }

--- a/conf/local.json
+++ b/conf/local.json
@@ -22,6 +22,7 @@
         "minProjects": 50,
         "lowGiB": 128,
         "highGiB": 256,
-        "intervalMillis": 3600000
+        "intervalMillis": 3600000,
+        "compressionMethod": "bzip2"
     }
 }

--- a/conf/local.json
+++ b/conf/local.json
@@ -23,6 +23,6 @@
         "lowGiB": 128,
         "highGiB": 256,
         "intervalMillis": 3600000,
-        "compressionMethod": "bzip2"
+        "compressionMethod": "gzip"
     }
 }

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DBStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/DBStore.java
@@ -24,6 +24,12 @@ public interface DBStore {
 
     String getOldestUnswappedProject();
 
+    void swap(String projectName, String compressionMethod);
+
+    void restore(String projectName);
+
+    String getSwapCompression(String projectName);
+
     int getNumUnswappedProjects();
 
     ProjectState getProjectState(String projectName);

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/noop/NoopDbStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/noop/NoopDbStore.java
@@ -60,7 +60,16 @@ public class NoopDbStore implements DBStore {
 
     @Override
     public void setLastAccessedTime(String projectName, Timestamp time) {
-
     }
 
+    @Override
+    public void swap(String projectName, String compressionMethod) {}
+
+    @Override
+    public void restore(String projectName) {}
+
+    @Override
+    public String getSwapCompression(String projectName) {
+        return null;
+    }
 }

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/query/GetSwapCompression.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/query/GetSwapCompression.java
@@ -1,0 +1,39 @@
+package uk.ac.ic.wlgitbridge.bridge.db.sqlite.query;
+
+import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SQLQuery;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class GetSwapCompression implements SQLQuery<String> {
+  private static final String GET_SWAP_COMPRESSION =
+    "SELECT `swap_compression` FROM `projects` WHERE `name` = ?";
+
+  private final String projectName;
+
+  public GetSwapCompression(String projectName) {
+    this.projectName = projectName;
+  }
+
+  @Override
+  public String processResultSet(ResultSet resultSet) throws SQLException {
+    String compression = null;
+    while (resultSet.next()) {
+      compression = resultSet.getString("swap_compression");
+    }
+    return compression;
+  }
+
+  @Override
+  public String getSQL() {
+    return GET_SWAP_COMPRESSION;
+  }
+
+  @Override
+  public void addParametersToStatement(
+    PreparedStatement statement
+  ) throws SQLException {
+    statement.setString(1, projectName);
+  }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/query/RestoreTimeColumnExists.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/query/RestoreTimeColumnExists.java
@@ -1,0 +1,26 @@
+package uk.ac.ic.wlgitbridge.bridge.db.sqlite.query;
+
+import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SQLQuery;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class RestoreTimeColumnExists implements SQLQuery<Boolean> {
+    private static final String RESTORE_TIME_COLUMN_EXISTS =
+            "PRAGMA table_info(`projects`)";
+
+    @Override
+    public String getSQL() {
+        return RESTORE_TIME_COLUMN_EXISTS;
+    }
+
+    @Override
+    public Boolean processResultSet(ResultSet resultSet) throws SQLException {
+        while (resultSet.next()) {
+            if (resultSet.getString(2).equals("restore_time")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/query/SwapCompressionColumnExists.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/query/SwapCompressionColumnExists.java
@@ -1,0 +1,27 @@
+package uk.ac.ic.wlgitbridge.bridge.db.sqlite.query;
+
+import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SQLQuery;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class SwapCompressionColumnExists implements SQLQuery<Boolean> {
+    private static final String SWAP_COMPRESSION_COLUMN_EXISTS =
+            "PRAGMA table_info(`projects`)";
+
+    @Override
+    public String getSQL() {
+        return SWAP_COMPRESSION_COLUMN_EXISTS;
+    }
+
+    @Override
+    public Boolean processResultSet(ResultSet resultSet) throws SQLException {
+        while (resultSet.next()) {
+            if (resultSet.getString(2).equals("swap_compression")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/query/SwapTimeColumnExists.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/query/SwapTimeColumnExists.java
@@ -1,0 +1,27 @@
+package uk.ac.ic.wlgitbridge.bridge.db.sqlite.query;
+
+import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SQLQuery;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class SwapTimeColumnExists implements SQLQuery<Boolean> {
+    private static final String SWAP_TIME_COLUMN_EXISTS =
+            "PRAGMA table_info(`projects`)";
+
+    @Override
+    public String getSQL() {
+        return SWAP_TIME_COLUMN_EXISTS;
+    }
+
+    @Override
+    public Boolean processResultSet(ResultSet resultSet) throws SQLException {
+        while (resultSet.next()) {
+            if (resultSet.getString(2).equals("swap_time")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/alter/ProjectsAddRestoreTime.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/alter/ProjectsAddRestoreTime.java
@@ -1,0 +1,14 @@
+package uk.ac.ic.wlgitbridge.bridge.db.sqlite.update.alter;
+
+import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SQLUpdate;
+
+public class ProjectsAddRestoreTime implements SQLUpdate {
+  private static final String PROJECTS_ADD_RESTORE_TIME =
+    "ALTER TABLE `projects`\n" +
+      "ADD COLUMN `restore_time` DATETIME NULL;\n";
+
+  @Override
+  public String getSQL() {
+    return PROJECTS_ADD_RESTORE_TIME;
+  }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/alter/ProjectsAddSwapCompression.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/alter/ProjectsAddSwapCompression.java
@@ -1,0 +1,14 @@
+package uk.ac.ic.wlgitbridge.bridge.db.sqlite.update.alter;
+
+import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SQLUpdate;
+
+public class ProjectsAddSwapCompression implements SQLUpdate {
+  private static final String PROJECTS_ADD_SWAP_COMPRESSION =
+    "ALTER TABLE `projects`\n" +
+      "ADD COLUMN `swap_compression` VARCHAR NULL;\n";
+
+  @Override
+  public String getSQL() {
+    return PROJECTS_ADD_SWAP_COMPRESSION;
+  }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/alter/ProjectsAddSwapTime.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/alter/ProjectsAddSwapTime.java
@@ -1,0 +1,15 @@
+package uk.ac.ic.wlgitbridge.bridge.db.sqlite.update.alter;
+
+import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SQLUpdate;
+
+public class ProjectsAddSwapTime implements SQLUpdate {
+  private static final String PROJECTS_ADD_SWAP_TIME =
+    "ALTER TABLE `projects`\n" +
+      "ADD COLUMN `swap_time` DATETIME NULL;\n";
+
+  @Override
+  public String getSQL() {
+    return PROJECTS_ADD_SWAP_TIME;
+  }
+
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/create/CreateProjectsTableSQLUpdate.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/create/CreateProjectsTableSQLUpdate.java
@@ -12,6 +12,9 @@ public class CreateProjectsTableSQLUpdate implements SQLUpdate {
             "    `name` VARCHAR NOT NULL DEFAULT '',\n" +
             "    `version_id` INT NOT NULL DEFAULT 0,\n" +
             "    `last_accessed` DATETIME NULL DEFAULT 0,\n" +
+            "    `swap_time` DATETIME NULL,\n" +
+            "    `restore_time` DATETIME NULL,\n" +
+            "    `swap_compression` VARCHAR NULL,\n" +
             "    PRIMARY KEY (`name`)\n" +
             ")";
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/insert/UpdateRestore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/insert/UpdateRestore.java
@@ -1,0 +1,40 @@
+package uk.ac.ic.wlgitbridge.bridge.db.sqlite.update.insert;
+
+import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SQLUpdate;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+public class UpdateRestore implements SQLUpdate {
+  private static final String UPDATE_RESTORE =
+    "UPDATE `projects`\n" +
+      "SET `last_accessed` = ?,\n" +
+      "    `swap_time` = NULL,\n" +
+      "    `restore_time` = ?,\n" +
+      "    `swap_compression` = NULL\n" +
+      "WHERE `name` = ?;\n";
+
+  private final String projectName;
+  private final Timestamp now;
+
+  public UpdateRestore(String projectName) {
+    this.projectName = projectName;
+    this.now = Timestamp.valueOf(LocalDateTime.now());
+  }
+
+  @Override
+  public String getSQL() {
+    return UPDATE_RESTORE;
+  }
+
+  @Override
+  public void addParametersToStatement(
+    PreparedStatement statement
+  ) throws SQLException {
+    statement.setTimestamp(1, now);
+    statement.setTimestamp(2, now);
+    statement.setString(3, projectName);
+  }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/insert/UpdateSwap.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/update/insert/UpdateSwap.java
@@ -1,0 +1,42 @@
+package uk.ac.ic.wlgitbridge.bridge.db.sqlite.update.insert;
+
+import uk.ac.ic.wlgitbridge.bridge.db.sqlite.SQLUpdate;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+public class UpdateSwap implements SQLUpdate {
+  private static final String UPDATE_SWAP =
+    "UPDATE `projects`\n" +
+      "SET `last_accessed` = NULL,\n" +
+      "    `swap_time` = ?,\n" +
+      "    `restore_time` = NULL,\n" +
+      "    `swap_compression` = ?\n" +
+      "WHERE `name` = ?;\n";
+
+  private final String projectName;
+  private final String compression;
+  private final Timestamp now;
+
+  public UpdateSwap(String projectName, String compression) {
+    this.projectName = projectName;
+    this.compression = compression;
+    this.now = Timestamp.valueOf(LocalDateTime.now());
+  }
+
+  @Override
+  public String getSQL() {
+    return UPDATE_SWAP;
+  }
+
+  @Override
+  public void addParametersToStatement(
+    PreparedStatement statement
+  ) throws SQLException {
+    statement.setTimestamp(1, now);
+    statement.setString(2, compression);
+    statement.setString(3, projectName);
+  }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStore.java
@@ -140,6 +140,15 @@ public class FSGitRepoStore implements RepoStore {
     }
 
     @Override
+    public InputStream gzipProject(
+        String projectName,
+        long[] sizePtr
+    ) throws IOException {
+        Project.checkValidProjectName(projectName);
+        return Tar.gzip.zip(getDotGitForProject(projectName), sizePtr);
+    }
+
+    @Override
     public void gcProject(String projectName) throws IOException {
         Project.checkValidProjectName(projectName);
         ProjectRepo repo = getExistingRepo(projectName);
@@ -169,6 +178,25 @@ public class FSGitRepoStore implements RepoStore {
                 projectName
         );
         Tar.bz2.unzip(dataStream, getDirForProject(projectName));
+    }
+
+    @Override
+    public void ungzipProject(
+      String projectName,
+      InputStream dataStream
+    ) throws IOException {
+        Preconditions.checkArgument(
+            Project.isValidProjectName(projectName),
+            "[%s] invalid project name: ",
+            projectName
+        );
+        Preconditions.checkState(
+            getDirForProject(projectName).mkdirs(),
+          "[%s] directories for " +
+            "evicted project already exist",
+            projectName
+        );
+        Tar.gzip.unzip(dataStream, getDirForProject(projectName));
     }
 
     private File getDirForProject(String projectName) {

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/FSGitRepoStore.java
@@ -136,6 +136,7 @@ public class FSGitRepoStore implements RepoStore {
             long[] sizePtr
     ) throws IOException {
         Project.checkValidProjectName(projectName);
+        Log.info("[{}] bzip2 project", projectName);
         return Tar.bz2.zip(getDotGitForProject(projectName), sizePtr);
     }
 
@@ -145,6 +146,7 @@ public class FSGitRepoStore implements RepoStore {
         long[] sizePtr
     ) throws IOException {
         Project.checkValidProjectName(projectName);
+        Log.info("[{}] gzip project", projectName);
         return Tar.gzip.zip(getDotGitForProject(projectName), sizePtr);
     }
 
@@ -177,6 +179,7 @@ public class FSGitRepoStore implements RepoStore {
                         "evicted project already exist",
                 projectName
         );
+        Log.info("[{}] un-bzip2 project", projectName);
         Tar.bz2.unzip(dataStream, getDirForProject(projectName));
     }
 
@@ -196,6 +199,7 @@ public class FSGitRepoStore implements RepoStore {
             "evicted project already exist",
             projectName
         );
+        Log.info("[{}] un-gzip project", projectName);
         Tar.gzip.unzip(dataStream, getDirForProject(projectName));
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/RepoStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/repo/RepoStore.java
@@ -50,6 +50,22 @@ public interface RepoStore {
         return bzip2Project(projectName, null);
     }
 
+    /**
+     * Tars and gzips the .git directory of the given project. Throws an
+     * IOException if the project doesn't exist. The returned stream is a copy
+     * of the original .git directory, which must be deleted using remove().
+     */
+    InputStream gzipProject(
+        String projectName,
+        long[] sizePtr
+    ) throws IOException;
+
+    default InputStream gzipProject(
+        String projectName
+    ) throws IOException {
+        return gzipProject(projectName, null);
+    }
+
     void gcProject(String projectName) throws IOException;
 
     /**
@@ -71,6 +87,18 @@ public interface RepoStore {
     void unbzip2Project(
             String projectName,
             InputStream dataStream
+    ) throws IOException;
+
+    /**
+     * Ungzips the given data stream into a .git directory for projectName.
+     * Creates the project's git directory.
+     * If projectName already exists, throws an IOException.
+     * @param projectName the name of the project, e.g. abc123
+     * @param dataStream the data stream containing the gzip contents.
+     */
+    void ungzipProject(
+        String projectName,
+        InputStream dataStream
     ) throws IOException;
 
 }

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJob.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJob.java
@@ -13,6 +13,46 @@ import java.util.Optional;
  */
 public interface SwapJob {
 
+    enum CompressionMethod { Bzip2, Gzip }
+
+    static CompressionMethod stringToCompressionMethod(String compressionString) {
+        if (compressionString == null) {
+            return null;
+        }
+        CompressionMethod result;
+        switch (compressionString) {
+            case "gzip":
+                result = CompressionMethod.Gzip;
+                break;
+            case "bzip2":
+                result = CompressionMethod.Bzip2;
+                break;
+            default:
+                result = null;
+                break;
+        }
+        return result;
+    }
+
+    static String compressionMethodAsString(CompressionMethod compressionMethod) {
+        if (compressionMethod == null) {
+            return null;
+        }
+        String result;
+        switch (compressionMethod) {
+            case Gzip:
+                result =  "gzip";
+                break;
+            case Bzip2:
+                result =  "bzip2";
+                break;
+            default:
+                result =  null;
+                break;
+        }
+        return result;
+    }
+
     static SwapJob fromConfig(
             Optional<SwapJobConfig> cfg,
             ProjectLock lock,

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobConfig.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobConfig.java
@@ -1,5 +1,8 @@
 package uk.ac.ic.wlgitbridge.bridge.swap.job;
 
+import uk.ac.ic.wlgitbridge.util.Log;
+import uk.ac.ic.wlgitbridge.bridge.swap.job.SwapJob.CompressionMethod;
+
 /**
  * Created by winston on 23/08/2016.
  */
@@ -9,17 +12,20 @@ public class SwapJobConfig {
     private final int lowGiB;
     private final int highGiB;
     private final long intervalMillis;
+    private final String compressionMethod;
 
     public SwapJobConfig(
             int minProjects,
             int lowGiB,
             int highGiB,
-            long intervalMillis
+            long intervalMillis,
+            String compressionMethod
     ) {
         this.minProjects = minProjects;
         this.lowGiB = lowGiB;
         this.highGiB = highGiB;
         this.intervalMillis = intervalMillis;
+        this.compressionMethod = compressionMethod;
     }
 
     public int getMinProjects() {
@@ -38,4 +44,12 @@ public class SwapJobConfig {
         return intervalMillis;
     }
 
+    public SwapJob.CompressionMethod getCompressionMethod() {
+      CompressionMethod result = SwapJob.stringToCompressionMethod(compressionMethod);
+      if (result == null) {
+        Log.info("SwapJobConfig: un-supported compressionMethod '{}', default to 'bzip2'", compressionMethod);
+        result = CompressionMethod.Bzip2;
+      }
+      return result;
+    }
 }

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -667,7 +667,7 @@ public class WLGitBridgeIntegrationTest {
         server.start();
         server.setState(states.get("wlgbCanSwapProjects").get("state"));
         wlgb = new GitBridgeApp(new String[] {
-                makeConfigFile(33874, 3874, new SwapJobConfig(1, 0, 0, 250))
+                makeConfigFile(33874, 3874, new SwapJobConfig(1, 0, 0, 250, null))
         });
         wlgb.run();
         File rootGitDir = new File(wlgb.config.getRootGitDirectory());

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/SqliteDBStoreTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/SqliteDBStoreTest.java
@@ -70,9 +70,22 @@ public class SqliteDBStoreTest {
     }
 
     @Test
+    public void swapAndRestore() {
+      String projectName = "something";
+      String compression = "bzip2";
+      dbStore.setLatestVersionForProject(projectName, 42);
+      dbStore.swap(projectName, compression);
+      assertNull(dbStore.getOldestUnswappedProject());
+      assertEquals(dbStore.getSwapCompression(projectName), compression);
+      // and restore
+      dbStore.restore(projectName);
+      assertEquals(dbStore.getSwapCompression(projectName), null);
+    }
+
+    @Test
     public void noOldestProjectIfAllEvicted() {
         dbStore.setLatestVersionForProject("older", 3);
-        dbStore.setLastAccessedTime("older", null);
+        dbStore.swap("older", "bzip2");
         assertNull(dbStore.getOldestUnswappedProject());
     }
 
@@ -93,7 +106,7 @@ public class SqliteDBStoreTest {
                 )
         );
         assertEquals("older", dbStore.getOldestUnswappedProject());
-        dbStore.setLastAccessedTime("older", null);
+        dbStore.swap("older", "bzip2");
         assertEquals("newer", dbStore.getOldestUnswappedProject());
     }
 
@@ -115,9 +128,9 @@ public class SqliteDBStoreTest {
                 Timestamp.valueOf(LocalDateTime.now())
         );
         assertEquals(1, dbStore.getNumUnswappedProjects());
-        dbStore.setLastAccessedTime(
+        dbStore.swap(
                 "asdf",
-                null
+                "bzip2"
         );
         assertEquals(0, dbStore.getNumUnswappedProjects());
     }
@@ -143,7 +156,7 @@ public class SqliteDBStoreTest {
     @Test
     public void projectStateIsSwappedIfLastAccessedIsNull() {
         dbStore.setLatestVersionForProject("asdf", 1);
-        dbStore.setLastAccessedTime("asdf", null);
+        dbStore.swap("asdf", "bzip2");
         assertEquals(ProjectState.SWAPPED, dbStore.getProjectState("asdf"));
     }
 

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImplTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/swap/job/SwapJobImplTest.java
@@ -83,13 +83,17 @@ public class SwapJobImplTest {
         }
     }
 
+    private void waitASecond() {
+        try { Thread.sleep(1 * 1000); } catch (Exception _e) {}
+    }
+
     @Test
     public void startingTimerAlwaysCausesASwap() {
         swapJob.lowWatermarkBytes = 16384;
         swapJob.interval = Duration.ofHours(1);
         assertEquals(0, swapJob.swaps.get());
         swapJob.start();
-        while (swapJob.swaps.get() <= 0);
+        do { waitASecond(); } while (swapJob.swaps.get() <= 0);
         assertTrue(swapJob.swaps.get() > 0);
     }
 
@@ -98,7 +102,7 @@ public class SwapJobImplTest {
         swapJob.lowWatermarkBytes = 16384;
         assertEquals(0, swapJob.swaps.get());
         swapJob.start();
-        while (swapJob.swaps.get() <= 1);
+        do { waitASecond(); } while (swapJob.swaps.get() <= 1);
         assertTrue(swapJob.swaps.get() > 1);
     }
 
@@ -107,7 +111,7 @@ public class SwapJobImplTest {
         swapJob.highWatermarkBytes = 65536;
         assertEquals(2, dbStore.getNumUnswappedProjects());
         swapJob.start();
-        while (swapJob.swaps.get() < 1);
+        do { waitASecond(); } while (swapJob.swaps.get() < 1);
         assertEquals(2, dbStore.getNumUnswappedProjects());
     }
 
@@ -118,14 +122,14 @@ public class SwapJobImplTest {
         assertEquals(2, dbStore.getNumUnswappedProjects());
         assertEquals("proj2", dbStore.getOldestUnswappedProject());
         swapJob.start();
-        while (swapJob.swaps.get() < 1);
+        do { waitASecond(); } while (swapJob.swaps.get() < 1);
         assertEquals(1, dbStore.getNumUnswappedProjects());
         assertEquals("proj1", dbStore.getOldestUnswappedProject());
         assertEquals("bzip2", dbStore.getSwapCompression("proj2"));
         swapJob.restore("proj2");
         assertEquals(null, dbStore.getSwapCompression("proj2"));
         int numSwaps = swapJob.swaps.get();
-        while (swapJob.swaps.get() <= numSwaps);
+        do { waitASecond(); } while (swapJob.swaps.get() <= numSwaps);
         assertEquals(1, dbStore.getNumUnswappedProjects());
         assertEquals("proj2", dbStore.getOldestUnswappedProject());
     }
@@ -147,14 +151,14 @@ public class SwapJobImplTest {
         assertEquals(2, dbStore.getNumUnswappedProjects());
         assertEquals("proj2", dbStore.getOldestUnswappedProject());
         swapJob.start();
-        while (swapJob.swaps.get() < 1);
+        do { waitASecond(); } while (swapJob.swaps.get() < 1);
         assertEquals(1, dbStore.getNumUnswappedProjects());
         assertEquals("proj1", dbStore.getOldestUnswappedProject());
         assertEquals("gzip", dbStore.getSwapCompression("proj2"));
         swapJob.restore("proj2");
         assertEquals(null, dbStore.getSwapCompression("proj2"));
         int numSwaps = swapJob.swaps.get();
-        while (swapJob.swaps.get() <= numSwaps);
+        do { waitASecond(); } while (swapJob.swaps.get() <= numSwaps);
         assertEquals(1, dbStore.getNumUnswappedProjects());
         assertEquals("proj2", dbStore.getOldestUnswappedProject());
     }


### PR DESCRIPTION
## Description

Add Gzip support to the Swap system.


### Context

When Git-Bridge "swaps" a project out to S3, it compresses the repository with `bzip2` compression. This type of compression is very CPU intensive, and does not give us much of a compression advantage.

This PR allows us to use `gzip` compression instead, and to record (in the database) the type of compression used on each project, so we can use the appropriate de-compressor when the project is restored.


### Changes

- Add a new configuration option: `swapJob.compressionMethod`, options are `"bzip2"` and `"gzip"`
  - (defaults to `"bzip2"`, the current implementation)
- Add `gzip` support to the {de}compression code
- Add three new columns to the `projects` table:
  - `swap_time`
  - `restore_time`
  - `swap_compression`
- Add new methods to the Database layer: `.swap(projectName, compressionMethod)`, `.getSwapCompression(projectName)`, and `.restore(projectName)`
  - These update the database columns as appropriate
- Change the SwapJob system to use the configured compression method when swapping or restoring a project, and to use the new database methods
- Update tests to verify the metadata is set correctly


## Related Issues / PRs

- Closes https://github.com/overleaf/issues/issues/3683
- Part of https://github.com/overleaf/issues/issues/3558
- Postgres compatibility is on a separate branch: `sk-gzip-postgres`

## Review Notes

- Note that in the Swap system, the marker of a project being swapped is that it's `last_accessed_time` is set to `null`. In this PR I elected to _not_ add a new, explicit `is_swapped` column
- The way the Sqlite database is initialized is a bit unusual, where the "migration" functions are run before the tables are created. This lead to some strange problems in testing versus the dev environment. I haven't changed the overall logic, but just be aware that yes, it _is_ a bit strange that the initialization is done like this.


## Deployment

### Configuration

We will need to add `swapJob.compressionMethod = "gzip"` to the production configuration.

### Database Migration

We will need to run the following database migration during downtime, before booting the new app:

```sql
-- Sqlite

ALTER TABLE `projects`
  ADD COLUMN `swap_time` DATETIME NULL;
  
ALTER TABLE `projects`
  ADD COLUMN `restore_time` DATETIME NULL;

ALTER TABLE `projects`
  ADD COLUMN `swap_compression` VARCHAR NULL;

UPDATE `projects`
  SET `swap_compression` = 'bzip2'
  WHERE `last_accessed` IS NULL;
```

## Deployment Plan

- Stop the git-bridge service
- Configure `compressionMethod = bzip2`
- Deploy this PR
  - Keep the git-bridge service offline
- While offline, run migration
- Start the service
- Check that everything is working
- Configure `compressionMethod = gzip`
- Deploy the service again
- Check that everything is working

## Manual Testing

I have run a local test, using s3 as the swap store, migrating from the master branch (with bzip compression), so this sk-gzip branch (with gzip compression), and everything appears to work as expected.

Projects are compressed with the configured algorithm, sent to s3, and decompressed with the appropriate algorithm when they are restored.