### PR TITLE
Allow configuration of AWS region

### DIFF
--- a/conf/example_config.json
+++ b/conf/example_config.json
@@ -19,7 +19,8 @@
         "type": "s3",
         "awsAccessKey": "asdf",
         "awsSecret": "asdf",
-        "s3BucketName": "com.overleaf.testbucket"
+        "s3BucketName": "com.overleaf.testbucket",
+        "awsRegion": "us-east-1"
     },
     "swapJob": {
         "minProjects": 50,

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/store/S3SwapStore.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/store/S3SwapStore.java
@@ -21,16 +21,29 @@ public class S3SwapStore implements SwapStore {
         this(
                 cfg.getAwsAccessKey(),
                 cfg.getAwsSecret(),
-                cfg.getS3BucketName()
+                cfg.getS3BucketName(),
+                cfg.getAwsRegion()
         );
     }
 
     S3SwapStore(
             String accessKey,
             String secret,
-            String bucketName
+            String bucketName,
+            String region
     ) {
-        s3 = AmazonS3ClientBuilder.standard().withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secret))).build();
+        String regionToUse = null;
+        if (region == null) {
+            regionToUse = "us-east-1";
+        } else {
+            regionToUse = region;
+        }
+        s3 = AmazonS3ClientBuilder
+                .standard()
+                .withRegion(regionToUse)
+                .withCredentials(
+                        new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secret))
+                ).build();
         this.bucketName = bucketName;
     }
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/store/SwapStoreConfig.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/swap/store/SwapStoreConfig.java
@@ -9,6 +9,7 @@ public class SwapStoreConfig {
             "noop",
             null,
             null,
+            null,
             null
     );
 
@@ -16,19 +17,22 @@ public class SwapStoreConfig {
     private String awsAccessKey;
     private String awsSecret;
     private String s3BucketName;
+    private String awsRegion;
 
     public SwapStoreConfig() {}
 
     public SwapStoreConfig(
             String awsAccessKey,
             String awsSecret,
-            String s3BucketName
+            String s3BucketName,
+            String awsRegion
     ) {
         this(
                 "s3",
                 awsAccessKey,
                 awsSecret,
-                s3BucketName
+                s3BucketName,
+                awsRegion
         );
     }
 
@@ -36,12 +40,14 @@ public class SwapStoreConfig {
             String type,
             String awsAccessKey,
             String awsSecret,
-            String s3BucketName
+            String s3BucketName,
+            String awsRegion
     ) {
         this.type = type;
         this.awsAccessKey = awsAccessKey;
         this.awsSecret = awsSecret;
         this.s3BucketName = s3BucketName;
+        this.awsRegion = awsRegion;
     }
 
     public String getType() {
@@ -60,12 +66,15 @@ public class SwapStoreConfig {
         return s3BucketName;
     }
 
+    public String getAwsRegion() { return awsRegion; }
+
     public SwapStoreConfig sanitisedCopy() {
         return new SwapStoreConfig(
                 type,
                 awsAccessKey == null ? null : "<awsAccessKey>",
                 awsSecret == null ? null : "<awsSecret>",
-                s3BucketName
+                s3BucketName,
+                awsRegion
         );
     }
 

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/swap/store/S3SwapStoreTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/swap/store/S3SwapStoreTest.java
@@ -10,6 +10,7 @@ public class S3SwapStoreTest {
     private static final String accessKey = null;
     private static final String secret = null;
     private static final String bucketName = "com.overleaf.testbucket";
+    private static final String region = "us-east-1";
 
     private S3SwapStore s3;
 
@@ -19,7 +20,7 @@ public class S3SwapStoreTest {
             s3 = null;
             return;
         }
-        s3 = new S3SwapStore(accessKey, secret, bucketName);
+        s3 = new S3SwapStore(accessKey, secret, bucketName, region);
     }
 
 //    @Ignore


### PR DESCRIPTION
## Description

Adds a new configuration option: `swapStore.awsRegion`. When the `s3` swap store is enabled, this option is used to set the AWS Region to connect to.

When this option is missing, it defaults to `"us-east-1"`.

The current behaviour is that the AWS client library _infers_ which region to use, but only when the application is running inside AWS infrastructure. 

This change makes the configuration explicit, and prepares the way for moving the application to GCP.


## Related Issues & PRs

- Closes https://github.com/overleaf/issues/issues/3957


## Testing

- [X] Manual test, with local connection to AWS
- [X] Default to 'us-east-1' 


## Deployment

- Need to set the option in the settings file: https://github.com/overleaf/write_latex_ops/pull/549