### PR TITLE
Remove basic auth configuration

### DIFF
--- a/conf/envsubst_template.json
+++ b/conf/envsubst_template.json
@@ -2,8 +2,6 @@
   "port": ${GIT_BRIDGE_PORT:-8000},
     "rootGitDirectory": "${GIT_BRIDGE_ROOT_DIR:-/tmp/wlgb}",
     "apiBaseUrl": "${GIT_BRIDGE_API_BASE_URL:-https://localhost/api/v0}",
-    "username": "${GIT_BRIDGE_USERNAME}",
-    "password": "${GIT_BRIDGE_PASSWORD}",
     "postbackBaseUrl": "${GIT_BRIDGE_POSTBACK_BASE_URL:-https://localhost}",
     "serviceName": "${GIT_BRIDGE_SERVICE_NAME:-Overleaf}",
     "oauth2": {

--- a/conf/example_config.json
+++ b/conf/example_config.json
@@ -2,8 +2,6 @@
     "port": 8080,
     "rootGitDirectory": "/tmp/wlgb",
     "apiBaseUrl": "https://localhost/api/v0",
-    "username": "user",
-    "password": "pass",
     "postbackBaseUrl": "https://localhost",
     "serviceName": "Overleaf",
     "oauth2": {

--- a/conf/local.json
+++ b/conf/local.json
@@ -2,8 +2,6 @@
     "port": 8000,
     "rootGitDirectory": "/tmp/wlgb",
     "apiBaseUrl": "http://v2.overleaf.test:4000/api/v0",
-    "username": "user",
-    "password": "pass",
     "postbackBaseUrl": "http://git-bridge:8000",
     "serviceName": "Overleaf",
     "oauth2": {

--- a/src/main/java/uk/ac/ic/wlgitbridge/application/config/Config.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/application/config/Config.java
@@ -25,8 +25,6 @@ public class Config implements JSONSource {
         return new Config(
                 config.port,
                 config.rootGitDirectory,
-                config.username,
-                "<password>",
                 config.apiBaseURL,
                 config.postbackURL,
                 config.serviceName,
@@ -39,8 +37,6 @@ public class Config implements JSONSource {
 
     private int port;
     private String rootGitDirectory;
-    private String username;
-    private String password;
     private String apiBaseURL;
     private String postbackURL;
     private String serviceName;
@@ -67,8 +63,6 @@ public class Config implements JSONSource {
     public Config(
             int port,
             String rootGitDirectory,
-            String username,
-            String password,
             String apiBaseURL,
             String postbackURL,
             String serviceName,
@@ -79,8 +73,6 @@ public class Config implements JSONSource {
     ) {
         this.port = port;
         this.rootGitDirectory = rootGitDirectory;
-        this.username = username;
-        this.password = password;
         this.apiBaseURL = apiBaseURL;
         this.postbackURL = postbackURL;
         this.serviceName = serviceName;
@@ -98,8 +90,6 @@ public class Config implements JSONSource {
                 configObject,
                 "rootGitDirectory"
         ).getAsString();
-        username = getOptionalString(configObject, "username");
-        password = getOptionalString(configObject, "password");
         String apiBaseURL = getElement(
                 configObject,
                 "apiBaseUrl"
@@ -136,14 +126,6 @@ public class Config implements JSONSource {
 
     public String getRootGitDirectory() {
         return rootGitDirectory;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public String getPassword() {
-        return password;
     }
 
     public String getAPIBaseURL() {

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -73,10 +73,6 @@ public class GitBridgeServer {
         );
         jettyServer = new Server(port);
         configureJettyServer(config, repoStore, snapshotApi);
-        SnapshotAPIRequest.setBasicAuth(
-                config.getUsername(),
-                config.getPassword()
-        );
         apiBaseURL = config.getAPIBaseURL();
         SnapshotAPIRequest.setBaseURL(apiBaseURL);
         Util.setServiceName(config.getServiceName());

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/SnapshotAPIRequest.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/SnapshotAPIRequest.java
@@ -11,9 +11,6 @@ import java.io.IOException;
  */
 public abstract class SnapshotAPIRequest<T extends Result> extends Request<T> {
 
-    private static String USERNAME;
-    private static String PASSWORD;
-
     private static String BASE_URL;
 
     private final Credential oauth2;
@@ -33,25 +30,9 @@ public abstract class SnapshotAPIRequest<T extends Result> extends Request<T> {
     ) throws IOException {
         if (oauth2 != null) {
             request.setInterceptor(request1 -> {
-                new BasicAuthentication(
-                        USERNAME,
-                        PASSWORD
-                ).intercept(request1);
                 oauth2.intercept(request1);
             });
-        } else {
-            request.setInterceptor(request1 -> {
-                new BasicAuthentication(
-                        USERNAME,
-                        PASSWORD
-                ).intercept(request1);
-            });
         }
-    }
-
-    public static void setBasicAuth(String username, String password) {
-        USERNAME = username;
-        PASSWORD = password;
     }
 
     /* baseURL ends with / */

--- a/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/SnapshotAPIRequest.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/snapshot/base/SnapshotAPIRequest.java
@@ -27,7 +27,7 @@ public abstract class SnapshotAPIRequest<T extends Result> extends Request<T> {
     @Override
     protected void onBeforeRequest(
             HttpRequest request
-    ) throws IOException {
+    ) {
         if (oauth2 != null) {
             request.setInterceptor(request1 -> {
                 oauth2.intercept(request1);

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -1069,8 +1069,6 @@ public class WLGitBridgeIntegrationTest {
                 "    \"apiBaseUrl\": \"http://127.0.0.1:" +
                         apiPort +
                         "/api/v0\",\n" +
-                "    \"username\": \"\",\n" +
-                "    \"password\": \"\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1:" +
                         port +
                         "\",\n" +

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/config/ConfigTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/config/ConfigTest.java
@@ -18,8 +18,6 @@ public class ConfigTest {
                 "    \"port\": 80,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
-                "    \"username\": \"REDACTED\",\n" +
-                "    \"password\": \"REDACTED\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
                 "    \"serviceName\": \"Overleaf\",\n" +
                 "    \"oauth2\": {\n" +
@@ -32,8 +30,6 @@ public class ConfigTest {
         assertEquals(80, config.getPort());
         assertEquals("/var/wlgb/git", config.getRootGitDirectory());
         assertEquals("http://127.0.0.1:60000/api/v0/", config.getAPIBaseURL());
-        assertEquals("REDACTED", config.getUsername());
-        assertEquals("REDACTED", config.getPassword());
         assertEquals("http://127.0.0.1/", config.getPostbackURL());
         assertEquals("Overleaf", config.getServiceName());
         assertTrue(config.isUsingOauth2());
@@ -48,8 +44,6 @@ public class ConfigTest {
                 "    \"port\": 80,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
-                "    \"username\": \"REDACTED\",\n" +
-                "    \"password\": \"REDACTED\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
                 "    \"serviceName\": \"Overleaf\",\n" +
                 "    \"oauth2\": null\n" +
@@ -58,8 +52,6 @@ public class ConfigTest {
         assertEquals(80, config.getPort());
         assertEquals("/var/wlgb/git", config.getRootGitDirectory());
         assertEquals("http://127.0.0.1:60000/api/v0/", config.getAPIBaseURL());
-        assertEquals("REDACTED", config.getUsername());
-        assertEquals("REDACTED", config.getPassword());
         assertEquals("http://127.0.0.1/", config.getPostbackURL());
         assertEquals("Overleaf", config.getServiceName());
         assertFalse(config.isUsingOauth2());
@@ -72,8 +64,6 @@ public class ConfigTest {
                 "    \"port\": 80,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
-                "    \"username\": \"username\",\n" +
-                "    \"password\": \"my super secret password\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
                 "    \"serviceName\": \"Overleaf\",\n" +
                 "    \"oauth2\": {\n" +
@@ -86,8 +76,6 @@ public class ConfigTest {
         String expected = "{\n" +
                 "  \"port\": 80,\n" +
                 "  \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
-                "  \"username\": \"username\",\n" +
-                "  \"password\": \"<password>\",\n" +
                 "  \"apiBaseURL\": \"http://127.0.0.1:60000/api/v0/\",\n" +
                 "  \"postbackURL\": \"http://127.0.0.1/\",\n" +
                 "  \"serviceName\": \"Overleaf\",\n" +

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/BridgeTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/BridgeTest.java
@@ -58,8 +58,6 @@ public class BridgeTest {
                         "",
                         "",
                         "",
-                        "",
-                        "",
                         null,
                         null,
                         null,


### PR DESCRIPTION
These were once used to secure interactions with the web api, back when
we allowed anonymous access to git repositories. This feature was
dropped in the migration to Overleaf v2, and we use OAuth on those
interactions anyway, so these settings are not actually used for
anything, and keeping these around is just confusing.

This issue was discovered while [moving git-bridge to GCP](https://github.com/overleaf/issues/issues/3558).

See this conversation for more of the rationale: https://github.com/overleaf/issues/issues/3558#issuecomment-845126095