### PR TITLE
Update JVM and add GC logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN make package \
 
 FROM openjdk:11-jre
 
-RUN apt-get update && apt-get install -y git sqlite3 \
+RUN apt-get update && apt-get install -y git sqlite3 procps htop net-tools sockstat \
  && rm -rf /var/lib/apt/lists
 
 RUN useradd --create-home node

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile for git-bridge
 
-FROM maven:3-jdk-8 as base
+FROM maven:3-jdk-11 as base
 
 RUN apt-get update && apt-get install -y make git \
  && rm -rf /var/lib/apt/lists
@@ -23,7 +23,7 @@ RUN make package \
       -name 'writelatex-git-bridge*jar-with-dependencies.jar' \
       -exec mv {} /git-bridge.jar \;
 
-FROM openjdk:8-jre
+FROM openjdk:11-jre
 
 RUN apt-get update && apt-get install -y git sqlite3 \
  && rm -rf /var/lib/apt/lists

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.13.0</version>
+            <version>3.11.1</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 /opt/envsubst < /envsubst_template.json > /conf/runtime.json
-exec java -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -jar /git-bridge.jar /conf/runtime.json
+exec java -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -Xlog:gc* -jar /git-bridge.jar /conf/runtime.json


### PR DESCRIPTION
Update JVM to version 11. Apparently, it has a better GC.

Also added a command to log out GC events so that we can see what it's doing, along with `procps` and a couple of other tools so that we can look at what's going on inside the container more easily.

I've tested the build locally and it works. We'll want to give it a pretty thorough check on staging.