### PR TITLE
Export prometheus metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,5 +194,23 @@
             <artifactId>commons-compress</artifactId>
             <version>1.15</version>
         </dependency>
+        <!-- prometheus metrics -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.10.0</version>
+        </dependency>
+        <!-- Hotspot JVM metrics -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>0.10.0</version>
+        </dependency>
+        <!-- Expose metrics via a servlet -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_servlet</artifactId>
+            <version>0.10.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -127,6 +127,7 @@ public class GitBridgeServer {
         handlers.addHandler(new StatusHandler(bridge));
         handlers.addHandler(new HealthCheckHandler(bridge));
         handlers.addHandler(new GitLfsHandler(bridge));
+        handlers.addHandler(new PrometheusHandler(bridge));
         base.setHandler(handlers);
         return base;
     }

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/PrometheusHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/PrometheusHandler.java
@@ -1,0 +1,55 @@
+package uk.ac.ic.wlgitbridge.server;
+
+import io.prometheus.client.exporter.MetricsServlet;
+import io.prometheus.client.hotspot.DefaultExports;
+
+import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.ic.wlgitbridge.bridge.Bridge;
+import uk.ac.ic.wlgitbridge.util.Log;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class PrometheusHandler extends AbstractHandler {
+
+  private final Bridge bridge;
+  private final MetricsServlet metricsServlet;
+  private final ServletHolder holder;
+
+  public PrometheusHandler(Bridge bridge) {
+    this.bridge = bridge;
+    this.metricsServlet = new MetricsServlet();
+    this.holder = new ServletHolder(metricsServlet);
+    DefaultExports.initialize();
+  }
+
+  @Override
+  public void handle(
+    String target,
+    Request baseRequest,
+    HttpServletRequest request,
+    HttpServletResponse response
+  ) throws IOException, ServletException {
+    String method = baseRequest.getMethod();
+    if (
+      ("GET".equals(method))
+        && target != null
+        && target.matches("^/metrics/?$")
+    ) {
+      Log.info(method + " <- /metrics");
+      response.setContentType("application/vnd.git-lfs+json");
+      response.setStatus(200);
+      this.holder.handle(baseRequest, request, response);
+      baseRequest.setHandled(true);
+    }
+  }
+
+}


### PR DESCRIPTION
This adds the Prometheus client and exposes the metrics on the default `/metrics` endpoint.

It adds support for the default Java metrics, plus the Jetty collector.