### PR TITLE
Upgrade jetty and jetty-servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.8.v20171121</version>
+            <version>9.4.38.v20210224</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.8.v20171121</version>
+            <version>9.4.38.v20210224</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-server -->
         <dependency>


### PR DESCRIPTION
Copy of https://github.com/overleaf/writelatex-git-bridge/pull/98, because cloud build can't handle the dependabot branch names.

Upgrade both jetty and jetty-servlet:
- jetty: 9.4.38.v20210224
- jetty-servlet: 9.4.38.v20210224
