### PR TITLE
Fix /metrics endpoint in latest Jetty.

### DIFF
--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -127,7 +127,7 @@ public class GitBridgeServer {
         handlers.addHandler(new StatusHandler(bridge));
         handlers.addHandler(new HealthCheckHandler(bridge));
         handlers.addHandler(new GitLfsHandler(bridge));
-        handlers.addHandler(new PrometheusHandler(bridge));
+        handlers.addHandler(new PrometheusHandler());
         base.setHandler(handlers);
         return base;
     }


### PR DESCRIPTION
Jetty 9.4.21 broke the `/metrics` endpoint. This patch uses the ServiceHolder lifecycle methods more carefully to ensure that the servlet is registered properly.
