### PR TITLE
Add diagnostics endpoint to debug native memory usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ runtime-conf:
 
 
 run: package runtime-conf
-	java -jar \
+	java $(GIT_BRIDGE_JVM_ARGS) -jar \
 	target/writelatex-git-bridge-1.0-SNAPSHOT-jar-with-dependencies.jar \
 	conf/runtime.json
 

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/DiagnosticsHandler.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/DiagnosticsHandler.java
@@ -1,0 +1,71 @@
+package uk.ac.ic.wlgitbridge.server;
+
+import org.eclipse.jetty.server.HttpConnection;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.ac.ic.wlgitbridge.bridge.Bridge;
+import uk.ac.ic.wlgitbridge.util.Log;
+
+import javax.management.JMException;
+import javax.management.ObjectName;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Writer;
+import java.lang.management.ManagementFactory;
+
+public class DiagnosticsHandler extends AbstractHandler {
+
+  public DiagnosticsHandler() {
+  }
+
+  @Override
+  public void handle(
+    String target,
+    Request baseRequest,
+    HttpServletRequest request,
+    HttpServletResponse response
+  ) throws IOException, ServletException {
+    String method = baseRequest.getMethod();
+    if (
+      ("GET".equals(method))
+        && target != null
+        && target.matches("^/diags/?$")
+    ) {
+      baseRequest.setHandled(true);
+
+      Log.info(method + " <- /diags");
+
+      String detail;
+      String summary;
+
+      try {
+        detail = execute("vmNativeMemory", "detail");
+        summary = execute("vmNativeMemory", "summary");
+      } catch(JMException e) {
+        Log.error("Failed to get native memory detail: " + e.getMessage());
+        response.setStatus(500);
+        return;
+      }
+      
+      response.setContentType("text/plain");
+      response.setStatus(200);
+
+      response.getWriter().write(summary);
+      response.getWriter().write("\n----------\n\n");
+      response.getWriter().write(detail);
+      response.getWriter().flush();
+    }
+  }
+
+  public static String execute(String command, String... args) throws JMException {
+    return (String) ManagementFactory.getPlatformMBeanServer().invoke(
+      new ObjectName("com.sun.management:type=DiagnosticCommand"),
+      command,
+      new Object[]{args},
+      new String[]{"[Ljava.lang.String;"});
+  }
+}

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -128,6 +128,7 @@ public class GitBridgeServer {
         handlers.addHandler(new HealthCheckHandler(bridge));
         handlers.addHandler(new GitLfsHandler(bridge));
         handlers.addHandler(new PrometheusHandler());
+        handlers.addHandler(new DiagnosticsHandler());
         base.setHandler(handlers);
         return base;
     }

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 /opt/envsubst < /envsubst_template.json > /conf/runtime.json
-exec java -XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0 -Xlog:gc* -jar /git-bridge.jar /conf/runtime.json
+
+if [ "x$GIT_BRIDGE_JVM_ARGS" == "x" ]; then
+  GIT_BRIDGE_JVM_ARGS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0"
+fi
+
+exec java $GIT_BRIDGE_JVM_ARGS -jar /git-bridge.jar /conf/runtime.json


### PR DESCRIPTION
It would be good to have access to native memory information in order to debug memory leaks in production. This can be exposed via the `-XX:NativeMemoryTracking=detail` JVM setting.

This PR

- Adds an endpoint to print the text output from this mechanism to `/diags`
- Allows configuring the JVM args via an environment variable so that this can be turned on and off
  - This also allows changing the other memory parameters without rebuilding the container

When `NativeMemoryTracking` is not enabled, the `/diags` endpoint prints "Native Memory Tracking is not enabled".