### PR TITLE
Add Google debug and profiling agents to Git Bridge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,15 @@ FROM openjdk:11-jre
 RUN apt-get update && apt-get install -y git sqlite3 procps htop net-tools sockstat \
  && rm -rf /var/lib/apt/lists
 
+# Install Google Cloud Profiler agent
 RUN mkdir -p /opt/cprof && \
   wget -q -O- https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent.tar.gz \
   | tar xzv -C /opt/cprof
+
+# Install Google Cloud Debugger agent
+RUN mkdir /opt/cdbg && \
+  wget -qO- https://storage.googleapis.com/cloud-debugger/compute-java/debian-wheezy/cdbg_java_agent_gce.tar.gz | \
+  tar xvz -C /opt/cdbg
 
 RUN useradd --create-home node
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ FROM openjdk:11-jre
 RUN apt-get update && apt-get install -y git sqlite3 procps htop net-tools sockstat \
  && rm -rf /var/lib/apt/lists
 
+RUN mkdir -p /opt/cprof && \
+  wget -q -O- https://storage.googleapis.com/cloud-profiler/java/latest/profiler_java_agent.tar.gz \
+  | tar xzv -C /opt/cprof
+
 RUN useradd --create-home node
 
 COPY --from=builder /git-bridge.jar /

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
+
 /opt/envsubst < /envsubst_template.json > /conf/runtime.json
 
 if [ "x$GIT_BRIDGE_JVM_ARGS" == "x" ]; then
   GIT_BRIDGE_JVM_ARGS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0"
+fi
+
+if [ "$ENABLE_PROFILE_AGENT" == "true" ]; then
+  GIT_BRIDGE_JVM_ARGS="-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=git-bridge,-cprof_service_version=1.0.0,-cprof_enable_heap_sampling=true ${GIT_BRIDGE_JVM_ARGS}"
 fi
 
 exec java $GIT_BRIDGE_JVM_ARGS -jar /git-bridge.jar /conf/runtime.json

--- a/start.sh
+++ b/start.sh
@@ -10,4 +10,8 @@ if [ "$ENABLE_PROFILE_AGENT" == "true" ]; then
   GIT_BRIDGE_JVM_ARGS="-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=git-bridge,-cprof_service_version=1.0.0,-cprof_enable_heap_sampling=true ${GIT_BRIDGE_JVM_ARGS}"
 fi
 
+if [ "$ENABLE_DEBUG_AGENT" == "true" ]; then
+  GIT_BRIDGE_JVM_ARGS="-agentpath:/opt/cdbg/cdbg_java_agent.so -Dcom.google.cdbg.module=git-bridge -Dcom.google.cdbg.version=$(date +%y%m%d%H%M%S) ${GIT_BRIDGE_JVM_ARGS}"
+fi
+
 exec java $GIT_BRIDGE_JVM_ARGS -jar /git-bridge.jar /conf/runtime.json


### PR DESCRIPTION
This installs the Google agents in the Dockerfile, and adds the required JVM args to run these.

Obeys the existing `ENABLE_PROFILE_AGENT` and `ENABLE_DEBUG_AGENT` vars used elsewhere in production, so no other ops changes are required.

Tested on staging and it works.