### PR TITLE
Use timestamp as version number for compiler

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,16 +2,18 @@
 
 /opt/envsubst < /envsubst_template.json > /conf/runtime.json
 
+VERSION=$(date +%y%m%d%H%M%S)
+
 if [ "x$GIT_BRIDGE_JVM_ARGS" == "x" ]; then
   GIT_BRIDGE_JVM_ARGS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=50.0"
 fi
 
 if [ "$ENABLE_PROFILE_AGENT" == "true" ]; then
-  GIT_BRIDGE_JVM_ARGS="-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=git-bridge,-cprof_service_version=1.0.0,-cprof_enable_heap_sampling=true ${GIT_BRIDGE_JVM_ARGS}"
+  GIT_BRIDGE_JVM_ARGS="-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=git-bridge,-cprof_service_version=${VERSION},-cprof_enable_heap_sampling=true ${GIT_BRIDGE_JVM_ARGS}"
 fi
 
 if [ "$ENABLE_DEBUG_AGENT" == "true" ]; then
-  GIT_BRIDGE_JVM_ARGS="-agentpath:/opt/cdbg/cdbg_java_agent.so -Dcom.google.cdbg.module=git-bridge -Dcom.google.cdbg.version=$(date +%y%m%d%H%M%S) ${GIT_BRIDGE_JVM_ARGS}"
+  GIT_BRIDGE_JVM_ARGS="-agentpath:/opt/cdbg/cdbg_java_agent.so -Dcom.google.cdbg.module=git-bridge -Dcom.google.cdbg.version=$VERSION ${GIT_BRIDGE_JVM_ARGS}"
 fi
 
 exec java $GIT_BRIDGE_JVM_ARGS -jar /git-bridge.jar /conf/runtime.json


### PR DESCRIPTION
Currently all profile data will be stored under the same version number. This makes it hard to compare profiles.

This patch will create a new version number every time the Git Bridge starts - which would be a mess if we were running multiple pods, but for the stateful set I think it's OK.