### PR TITLE
Add support for configuring idle timeout and bind IP via settings

### DIFF
--- a/conf/envsubst_template.json
+++ b/conf/envsubst_template.json
@@ -1,30 +1,32 @@
 {
   "port": ${GIT_BRIDGE_PORT:-8000},
-    "rootGitDirectory": "${GIT_BRIDGE_ROOT_DIR:-/tmp/wlgb}",
-    "apiBaseUrl": "${GIT_BRIDGE_API_BASE_URL:-https://localhost/api/v0}",
-    "postbackBaseUrl": "${GIT_BRIDGE_POSTBACK_BASE_URL:-https://localhost}",
-    "serviceName": "${GIT_BRIDGE_SERVICE_NAME:-Overleaf}",
-    "oauth2": {
-      "oauth2ClientID": "${GIT_BRIDGE_OAUTH2_CLIENT_ID}",
-      "oauth2ClientSecret": "${GIT_BRIDGE_OAUTH2_CLIENT_SECRET}",
-      "oauth2Server": "${GIT_BRIDGE_OAUTH2_SERVER:-https://localhost}"
-    },
-    "repoStore": {
-      "maxFileNum": ${GIT_BRIDGE_REPOSTORE_MAX_FILE_NUM:-2000},
-      "maxFileSize": ${GIT_BRIDGE_REPOSTORE_MAX_FILE_SIZE:-52428800}
-    },
-    "swapStore": {
-      "type": "${GIT_BRIDGE_SWAPSTORE_TYPE:-noop}",
-      "awsAccessKey": "${GIT_BRIDGE_SWAPSTORE_AWS_ACCESS_KEY}",
-      "awsSecret": "${GIT_BRIDGE_SWAPSTORE_AWS_SECRET}",
-      "s3BucketName": "${GIT_BRIDGE_SWAPSTORE_S3_BUCKET_NAME}",
-      "awsRegion": "${GIT_BRIDGE_SWAPSTORE_AWS_REGION:-us-east-1}"
-    },
-    "swapJob": {
-      "minProjects": ${GIT_BRIDGE_SWAPJOB_MIN_PROJECTS:-50},
-      "lowGiB": ${GIT_BRIDGE_SWAPJOB_LOW_GIB:-128},
-      "highGiB": ${GIT_BRIDGE_SWAPJOB_HIGH_GIB:-256},
-      "intervalMillis": ${GIT_BRIDGE_SWAPJOB_INTERVAL_MILLIS:-3600000},
-      "compressionMethod": "${GIT_BRIDGE_SWAPJOB_COMPRESSION_METHOD:-gzip}"
-    }
+  "bindIp": "${GIT_BRIDGE_BIND_IP:-0.0.0.0}",
+  "idleTimeout": "${GIT_BRIDGE_IDLE_TIMEOUT:-600000",
+  "rootGitDirectory": "${GIT_BRIDGE_ROOT_DIR:-/tmp/wlgb}",
+  "apiBaseUrl": "${GIT_BRIDGE_API_BASE_URL:-https://localhost/api/v0}",
+  "postbackBaseUrl": "${GIT_BRIDGE_POSTBACK_BASE_URL:-https://localhost}",
+  "serviceName": "${GIT_BRIDGE_SERVICE_NAME:-Overleaf}",
+  "oauth2": {
+    "oauth2ClientID": "${GIT_BRIDGE_OAUTH2_CLIENT_ID}",
+    "oauth2ClientSecret": "${GIT_BRIDGE_OAUTH2_CLIENT_SECRET}",
+    "oauth2Server": "${GIT_BRIDGE_OAUTH2_SERVER:-https://localhost}"
+  },
+  "repoStore": {
+    "maxFileNum": ${GIT_BRIDGE_REPOSTORE_MAX_FILE_NUM:-2000},
+    "maxFileSize": ${GIT_BRIDGE_REPOSTORE_MAX_FILE_SIZE:-52428800}
+  },
+  "swapStore": {
+    "type": "${GIT_BRIDGE_SWAPSTORE_TYPE:-noop}",
+    "awsAccessKey": "${GIT_BRIDGE_SWAPSTORE_AWS_ACCESS_KEY}",
+    "awsSecret": "${GIT_BRIDGE_SWAPSTORE_AWS_SECRET}",
+    "s3BucketName": "${GIT_BRIDGE_SWAPSTORE_S3_BUCKET_NAME}",
+    "awsRegion": "${GIT_BRIDGE_SWAPSTORE_AWS_REGION:-us-east-1}"
+  },
+  "swapJob": {
+    "minProjects": ${GIT_BRIDGE_SWAPJOB_MIN_PROJECTS:-50},
+    "lowGiB": ${GIT_BRIDGE_SWAPJOB_LOW_GIB:-128},
+    "highGiB": ${GIT_BRIDGE_SWAPJOB_HIGH_GIB:-256},
+    "intervalMillis": ${GIT_BRIDGE_SWAPJOB_INTERVAL_MILLIS:-3600000},
+    "compressionMethod": "${GIT_BRIDGE_SWAPJOB_COMPRESSION_METHOD:-gzip}"
+  }
 }

--- a/conf/example_config.json
+++ b/conf/example_config.json
@@ -1,5 +1,7 @@
 {
     "port": 8080,
+    "bindIp": "127.0.0.1",
+    "idleTimeout": 60000,
     "rootGitDirectory": "/tmp/wlgb",
     "apiBaseUrl": "https://localhost/api/v0",
     "postbackBaseUrl": "https://localhost",

--- a/conf/local.json
+++ b/conf/local.json
@@ -1,5 +1,7 @@
 {
     "port": 8000,
+    "bindIp": "0.0.0.0",
+    "idleTimeout": 600000,
     "rootGitDirectory": "/tmp/wlgb",
     "apiBaseUrl": "http://v2.overleaf.test:4000/api/v0",
     "postbackBaseUrl": "http://git-bridge:8000",

--- a/src/main/java/uk/ac/ic/wlgitbridge/application/config/Config.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/application/config/Config.java
@@ -24,6 +24,8 @@ public class Config implements JSONSource {
     static Config asSanitised(Config config) {
         return new Config(
                 config.port,
+                config.bindIp,
+                config.idleTimeout,
                 config.rootGitDirectory,
                 config.apiBaseURL,
                 config.postbackURL,
@@ -36,6 +38,8 @@ public class Config implements JSONSource {
     }
 
     private int port;
+    private String bindIp;
+    private int idleTimeout;
     private String rootGitDirectory;
     private String apiBaseURL;
     private String postbackURL;
@@ -62,6 +66,8 @@ public class Config implements JSONSource {
 
     public Config(
             int port,
+            String bindIp,
+            int idleTimeout,
             String rootGitDirectory,
             String apiBaseURL,
             String postbackURL,
@@ -72,6 +78,8 @@ public class Config implements JSONSource {
             SwapJobConfig swapJob
     ) {
         this.port = port;
+        this.bindIp = bindIp;
+        this.idleTimeout = idleTimeout;
         this.rootGitDirectory = rootGitDirectory;
         this.apiBaseURL = apiBaseURL;
         this.postbackURL = postbackURL;
@@ -86,6 +94,8 @@ public class Config implements JSONSource {
     public void fromJSON(JsonElement json) {
         JsonObject configObject = json.getAsJsonObject();
         port = getElement(configObject, "port").getAsInt();
+        bindIp = getElement(configObject, "bindIp").getAsString();
+        idleTimeout = getElement(configObject, "idleTimeout").getAsInt();
         rootGitDirectory = getElement(
                 configObject,
                 "rootGitDirectory"
@@ -122,6 +132,14 @@ public class Config implements JSONSource {
 
     public int getPort() {
         return port;
+    }
+
+    public String getBindIp() {
+        return bindIp;
+    }
+
+    public int getIdleTimeout() {
+        return idleTimeout;
     }
 
     public String getRootGitDirectory() {

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -2,6 +2,7 @@ package uk.ac.ic.wlgitbridge.server;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.*;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -71,7 +72,7 @@ public class GitBridgeServer {
                 swapStore,
                 snapshotApi
         );
-        jettyServer = new Server(port);
+        jettyServer = new Server();
         configureJettyServer(config, repoStore, snapshotApi);
         apiBaseURL = config.getAPIBaseURL();
         SnapshotAPIRequest.setBaseURL(apiBaseURL);
@@ -113,6 +114,12 @@ public class GitBridgeServer {
             RepoStore repoStore,
             SnapshotApi snapshotApi
     ) throws ServletException {
+        ServerConnector connector = new ServerConnector(this.jettyServer);
+        connector.setPort(config.getPort());
+        connector.setHost(config.getBindIp());
+        connector.setIdleTimeout(config.getIdleTimeout());
+        this.jettyServer.addConnector(connector);
+
         HandlerCollection handlers = new HandlerList();
         handlers.addHandler(initApiHandler());
         handlers.addHandler(initBaseHandler());

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -1063,6 +1063,8 @@ public class WLGitBridgeIntegrationTest {
         String cfgStr =
                 "{\n" +
                 "    \"port\": " + port + ",\n" +
+                "    \"bindIp\": \"127.0.0.1\",\n" +
+                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"" +
                         wlgb.getAbsolutePath() +
                         "\",\n" +

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/config/ConfigTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/config/ConfigTest.java
@@ -16,6 +16,8 @@ public class ConfigTest {
      public void testConstructWithOauth() {
         Reader reader = new StringReader("{\n" +
                 "    \"port\": 80,\n" +
+                "    \"bindIp\": \"127.0.0.1\",\n" +
+                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
@@ -42,6 +44,8 @@ public class ConfigTest {
     public void testConstructWithoutOauth() {
         Reader reader = new StringReader("{\n" +
                 "    \"port\": 80,\n" +
+                "    \"bindIp\": \"127.0.0.1\",\n" +
+                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
@@ -62,6 +66,8 @@ public class ConfigTest {
     public void asSanitised() throws Exception {
         Reader reader = new StringReader("{\n" +
                 "    \"port\": 80,\n" +
+                "    \"bindIp\": \"127.0.0.1\",\n" +
+                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
@@ -75,6 +81,8 @@ public class ConfigTest {
         Config config = new Config(reader);
         String expected = "{\n" +
                 "  \"port\": 80,\n" +
+                "  \"bindIp\": \"127.0.0.1\",\n" +
+                "  \"idleTimeout\": 30000,\n" +
                 "  \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "  \"apiBaseURL\": \"http://127.0.0.1:60000/api/v0/\",\n" +
                 "  \"postbackURL\": \"http://127.0.0.1/\",\n" +

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/BridgeTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/BridgeTest.java
@@ -55,6 +55,8 @@ public class BridgeTest {
                 new Config(
                         0,
                         "",
+                        0,
+                        "",
                         "",
                         "",
                         "",


### PR DESCRIPTION
Adds settings for `idleTimeout` and `bindIp` to settings, and uses a Jetty `ServerConnector` to supply them to the server.