### PR TITLE
Revert recent changes to Jetty

### DIFF
--- a/conf/envsubst_template.json
+++ b/conf/envsubst_template.json
@@ -1,7 +1,5 @@
 {
   "port": ${GIT_BRIDGE_PORT:-8000},
-  "bindIp": "${GIT_BRIDGE_BIND_IP:-0.0.0.0}",
-  "idleTimeout": ${GIT_BRIDGE_IDLE_TIMEOUT:-600000},
   "rootGitDirectory": "${GIT_BRIDGE_ROOT_DIR:-/tmp/wlgb}",
   "apiBaseUrl": "${GIT_BRIDGE_API_BASE_URL:-https://localhost/api/v0}",
   "postbackBaseUrl": "${GIT_BRIDGE_POSTBACK_BASE_URL:-https://localhost}",

--- a/conf/example_config.json
+++ b/conf/example_config.json
@@ -1,7 +1,5 @@
 {
     "port": 8080,
-    "bindIp": "127.0.0.1",
-    "idleTimeout": 60000,
     "rootGitDirectory": "/tmp/wlgb",
     "apiBaseUrl": "https://localhost/api/v0",
     "postbackBaseUrl": "https://localhost",

--- a/conf/local.json
+++ b/conf/local.json
@@ -1,7 +1,5 @@
 {
     "port": 8000,
-    "bindIp": "0.0.0.0",
-    "idleTimeout": 600000,
     "rootGitDirectory": "/tmp/wlgb",
     "apiBaseUrl": "http://v2.overleaf.test:4000/api/v0",
     "postbackBaseUrl": "http://git-bridge:8000",

--- a/pom.xml
+++ b/pom.xml
@@ -76,13 +76,13 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.38.v20210224</version>
+            <version>9.4.8.v20171121</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-server -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.38.v20210224</version>
+            <version>9.4.8.v20171121</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>

--- a/src/main/java/uk/ac/ic/wlgitbridge/application/config/Config.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/application/config/Config.java
@@ -24,8 +24,6 @@ public class Config implements JSONSource {
     static Config asSanitised(Config config) {
         return new Config(
                 config.port,
-                config.bindIp,
-                config.idleTimeout,
                 config.rootGitDirectory,
                 config.apiBaseURL,
                 config.postbackURL,
@@ -39,8 +37,6 @@ public class Config implements JSONSource {
     }
 
     private int port;
-    private String bindIp;
-    private int idleTimeout;
     private String rootGitDirectory;
     private String apiBaseURL;
     private String postbackURL;
@@ -68,8 +64,6 @@ public class Config implements JSONSource {
 
     public Config(
             int port,
-            String bindIp,
-            int idleTimeout,
             String rootGitDirectory,
             String apiBaseURL,
             String postbackURL,
@@ -81,8 +75,6 @@ public class Config implements JSONSource {
             int sqliteHeapLimitBytes
     ) {
         this.port = port;
-        this.bindIp = bindIp;
-        this.idleTimeout = idleTimeout;
         this.rootGitDirectory = rootGitDirectory;
         this.apiBaseURL = apiBaseURL;
         this.postbackURL = postbackURL;
@@ -98,8 +90,6 @@ public class Config implements JSONSource {
     public void fromJSON(JsonElement json) {
         JsonObject configObject = json.getAsJsonObject();
         port = getElement(configObject, "port").getAsInt();
-        bindIp = getElement(configObject, "bindIp").getAsString();
-        idleTimeout = getElement(configObject, "idleTimeout").getAsInt();
         rootGitDirectory = getElement(
                 configObject,
                 "rootGitDirectory"
@@ -139,14 +129,6 @@ public class Config implements JSONSource {
 
     public int getPort() {
         return port;
-    }
-
-    public String getBindIp() {
-        return bindIp;
-    }
-
-    public int getIdleTimeout() {
-        return idleTimeout;
     }
 
     public String getRootGitDirectory() {

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -2,7 +2,6 @@ package uk.ac.ic.wlgitbridge.server;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.*;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -73,7 +72,7 @@ public class GitBridgeServer {
                 swapStore,
                 snapshotApi
         );
-        jettyServer = new Server();
+        jettyServer = new Server(port);
         configureJettyServer(config, repoStore, snapshotApi);
         apiBaseURL = config.getAPIBaseURL();
         SnapshotAPIRequest.setBaseURL(apiBaseURL);
@@ -115,12 +114,6 @@ public class GitBridgeServer {
             RepoStore repoStore,
             SnapshotApi snapshotApi
     ) throws ServletException {
-        ServerConnector connector = new ServerConnector(this.jettyServer);
-        connector.setPort(config.getPort());
-        connector.setHost(config.getBindIp());
-        connector.setIdleTimeout(config.getIdleTimeout());
-        this.jettyServer.addConnector(connector);
-
         HandlerCollection handlers = new HandlerList();
         handlers.addHandler(initApiHandler());
         handlers.addHandler(initBaseHandler());

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -1063,8 +1063,6 @@ public class WLGitBridgeIntegrationTest {
         String cfgStr =
                 "{\n" +
                 "    \"port\": " + port + ",\n" +
-                "    \"bindIp\": \"127.0.0.1\",\n" +
-                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"" +
                         wlgb.getAbsolutePath() +
                         "\",\n" +

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/config/ConfigTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/config/ConfigTest.java
@@ -16,8 +16,6 @@ public class ConfigTest {
      public void testConstructWithOauth() {
         Reader reader = new StringReader("{\n" +
                 "    \"port\": 80,\n" +
-                "    \"bindIp\": \"127.0.0.1\",\n" +
-                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
@@ -44,8 +42,6 @@ public class ConfigTest {
     public void testConstructWithoutOauth() {
         Reader reader = new StringReader("{\n" +
                 "    \"port\": 80,\n" +
-                "    \"bindIp\": \"127.0.0.1\",\n" +
-                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
@@ -66,8 +62,6 @@ public class ConfigTest {
     public void asSanitised() throws Exception {
         Reader reader = new StringReader("{\n" +
                 "    \"port\": 80,\n" +
-                "    \"bindIp\": \"127.0.0.1\",\n" +
-                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
@@ -81,8 +75,6 @@ public class ConfigTest {
         Config config = new Config(reader);
         String expected = "{\n" +
                 "  \"port\": 80,\n" +
-                "  \"bindIp\": \"127.0.0.1\",\n" +
-                "  \"idleTimeout\": 30000,\n" +
                 "  \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "  \"apiBaseURL\": \"http://127.0.0.1:60000/api/v0/\",\n" +
                 "  \"postbackURL\": \"http://127.0.0.1/\",\n" +

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/BridgeTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/BridgeTest.java
@@ -55,8 +55,6 @@ public class BridgeTest {
                 new Config(
                         0,
                         "",
-                        0,
-                        "",
                         "",
                         "",
                         "",


### PR DESCRIPTION
Jetty was upgraded, and we made some changes to how it handles timeouts.

We are seeing users with timeout errors that appear to be coming from Jetty rather than the load balancer.

Reverting these to see if they could be the cause.