### PR TITLE
Revert jetty downgrade

### DIFF
--- a/conf/envsubst_template.json
+++ b/conf/envsubst_template.json
@@ -1,7 +1,7 @@
 {
   "port": ${GIT_BRIDGE_PORT:-8000},
   "bindIp": "${GIT_BRIDGE_BIND_IP:-0.0.0.0}",
-  "idleTimeout": ${GIT_BRIDGE_IDLE_TIMEOUT:-600000},
+  "idleTimeout": ${GIT_BRIDGE_IDLE_TIMEOUT:-30000},
   "rootGitDirectory": "${GIT_BRIDGE_ROOT_DIR:-/tmp/wlgb}",
   "apiBaseUrl": "${GIT_BRIDGE_API_BASE_URL:-https://localhost/api/v0}",
   "postbackBaseUrl": "${GIT_BRIDGE_POSTBACK_BASE_URL:-https://localhost}",

--- a/conf/envsubst_template.json
+++ b/conf/envsubst_template.json
@@ -1,5 +1,7 @@
 {
   "port": ${GIT_BRIDGE_PORT:-8000},
+  "bindIp": "${GIT_BRIDGE_BIND_IP:-0.0.0.0}",
+  "idleTimeout": ${GIT_BRIDGE_IDLE_TIMEOUT:-600000},
   "rootGitDirectory": "${GIT_BRIDGE_ROOT_DIR:-/tmp/wlgb}",
   "apiBaseUrl": "${GIT_BRIDGE_API_BASE_URL:-https://localhost/api/v0}",
   "postbackBaseUrl": "${GIT_BRIDGE_POSTBACK_BASE_URL:-https://localhost}",

--- a/conf/example_config.json
+++ b/conf/example_config.json
@@ -1,5 +1,7 @@
 {
     "port": 8080,
+    "bindIp": "127.0.0.1",
+    "idleTimeout": 60000,
     "rootGitDirectory": "/tmp/wlgb",
     "apiBaseUrl": "https://localhost/api/v0",
     "postbackBaseUrl": "https://localhost",

--- a/conf/example_config.json
+++ b/conf/example_config.json
@@ -1,7 +1,7 @@
 {
     "port": 8080,
     "bindIp": "127.0.0.1",
-    "idleTimeout": 60000,
+    "idleTimeout": 30000,
     "rootGitDirectory": "/tmp/wlgb",
     "apiBaseUrl": "https://localhost/api/v0",
     "postbackBaseUrl": "https://localhost",

--- a/conf/local.json
+++ b/conf/local.json
@@ -1,7 +1,7 @@
 {
     "port": 8000,
     "bindIp": "0.0.0.0",
-    "idleTimeout": 600000,
+    "idleTimeout": 30000,
     "rootGitDirectory": "/tmp/wlgb",
     "apiBaseUrl": "http://v2.overleaf.test:4000/api/v0",
     "postbackBaseUrl": "http://git-bridge:8000",

--- a/conf/local.json
+++ b/conf/local.json
@@ -1,5 +1,7 @@
 {
     "port": 8000,
+    "bindIp": "0.0.0.0",
+    "idleTimeout": 600000,
     "rootGitDirectory": "/tmp/wlgb",
     "apiBaseUrl": "http://v2.overleaf.test:4000/api/v0",
     "postbackBaseUrl": "http://git-bridge:8000",

--- a/pom.xml
+++ b/pom.xml
@@ -76,13 +76,13 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.8.v20171121</version>
+            <version>9.4.38.v20210224</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-server -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.8.v20171121</version>
+            <version>9.4.38.v20210224</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>

--- a/src/main/java/uk/ac/ic/wlgitbridge/application/config/Config.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/application/config/Config.java
@@ -24,6 +24,8 @@ public class Config implements JSONSource {
     static Config asSanitised(Config config) {
         return new Config(
                 config.port,
+                config.bindIp,
+                config.idleTimeout,
                 config.rootGitDirectory,
                 config.apiBaseURL,
                 config.postbackURL,
@@ -37,6 +39,8 @@ public class Config implements JSONSource {
     }
 
     private int port;
+    private String bindIp;
+    private int idleTimeout;
     private String rootGitDirectory;
     private String apiBaseURL;
     private String postbackURL;
@@ -64,6 +68,8 @@ public class Config implements JSONSource {
 
     public Config(
             int port,
+            String bindIp,
+            int idleTimeout,
             String rootGitDirectory,
             String apiBaseURL,
             String postbackURL,
@@ -75,6 +81,8 @@ public class Config implements JSONSource {
             int sqliteHeapLimitBytes
     ) {
         this.port = port;
+        this.bindIp = bindIp;
+        this.idleTimeout = idleTimeout;
         this.rootGitDirectory = rootGitDirectory;
         this.apiBaseURL = apiBaseURL;
         this.postbackURL = postbackURL;
@@ -90,6 +98,8 @@ public class Config implements JSONSource {
     public void fromJSON(JsonElement json) {
         JsonObject configObject = json.getAsJsonObject();
         port = getElement(configObject, "port").getAsInt();
+        bindIp = getElement(configObject, "bindIp").getAsString();
+        idleTimeout = getElement(configObject, "idleTimeout").getAsInt();
         rootGitDirectory = getElement(
                 configObject,
                 "rootGitDirectory"
@@ -129,6 +139,14 @@ public class Config implements JSONSource {
 
     public int getPort() {
         return port;
+    }
+
+    public String getBindIp() {
+        return bindIp;
+    }
+
+    public int getIdleTimeout() {
+        return idleTimeout;
     }
 
     public String getRootGitDirectory() {

--- a/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/server/GitBridgeServer.java
@@ -2,6 +2,7 @@ package uk.ac.ic.wlgitbridge.server;
 
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.*;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -72,7 +73,7 @@ public class GitBridgeServer {
                 swapStore,
                 snapshotApi
         );
-        jettyServer = new Server(port);
+        jettyServer = new Server();
         configureJettyServer(config, repoStore, snapshotApi);
         apiBaseURL = config.getAPIBaseURL();
         SnapshotAPIRequest.setBaseURL(apiBaseURL);
@@ -114,6 +115,12 @@ public class GitBridgeServer {
             RepoStore repoStore,
             SnapshotApi snapshotApi
     ) throws ServletException {
+        ServerConnector connector = new ServerConnector(this.jettyServer);
+        connector.setPort(config.getPort());
+        connector.setHost(config.getBindIp());
+        connector.setIdleTimeout(config.getIdleTimeout());
+        this.jettyServer.addConnector(connector);
+
         HandlerCollection handlers = new HandlerList();
         handlers.addHandler(initApiHandler());
         handlers.addHandler(initBaseHandler());

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/WLGitBridgeIntegrationTest.java
@@ -1063,6 +1063,8 @@ public class WLGitBridgeIntegrationTest {
         String cfgStr =
                 "{\n" +
                 "    \"port\": " + port + ",\n" +
+                "    \"bindIp\": \"127.0.0.1\",\n" +
+                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"" +
                         wlgb.getAbsolutePath() +
                         "\",\n" +

--- a/src/test/java/uk/ac/ic/wlgitbridge/application/config/ConfigTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/application/config/ConfigTest.java
@@ -16,6 +16,8 @@ public class ConfigTest {
      public void testConstructWithOauth() {
         Reader reader = new StringReader("{\n" +
                 "    \"port\": 80,\n" +
+                "    \"bindIp\": \"127.0.0.1\",\n" +
+                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
@@ -42,6 +44,8 @@ public class ConfigTest {
     public void testConstructWithoutOauth() {
         Reader reader = new StringReader("{\n" +
                 "    \"port\": 80,\n" +
+                "    \"bindIp\": \"127.0.0.1\",\n" +
+                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
@@ -62,6 +66,8 @@ public class ConfigTest {
     public void asSanitised() throws Exception {
         Reader reader = new StringReader("{\n" +
                 "    \"port\": 80,\n" +
+                "    \"bindIp\": \"127.0.0.1\",\n" +
+                "    \"idleTimeout\": 30000,\n" +
                 "    \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "    \"apiBaseUrl\": \"http://127.0.0.1:60000/api/v0\",\n" +
                 "    \"postbackBaseUrl\": \"http://127.0.0.1\",\n" +
@@ -75,6 +81,8 @@ public class ConfigTest {
         Config config = new Config(reader);
         String expected = "{\n" +
                 "  \"port\": 80,\n" +
+                "  \"bindIp\": \"127.0.0.1\",\n" +
+                "  \"idleTimeout\": 30000,\n" +
                 "  \"rootGitDirectory\": \"/var/wlgb/git\",\n" +
                 "  \"apiBaseURL\": \"http://127.0.0.1:60000/api/v0/\",\n" +
                 "  \"postbackURL\": \"http://127.0.0.1/\",\n" +

--- a/src/test/java/uk/ac/ic/wlgitbridge/bridge/BridgeTest.java
+++ b/src/test/java/uk/ac/ic/wlgitbridge/bridge/BridgeTest.java
@@ -55,6 +55,8 @@ public class BridgeTest {
                 new Config(
                         0,
                         "",
+                        0,
+                        "",
                         "",
                         "",
                         "",


### PR DESCRIPTION
Reverts the recent revert of the jetty upgrade (so this PR upgrades Jetty again) and re-adds the idle timeout mechanism, but with the default set back to 30sec. (Which is the Jetty default.)