### PR TITLE
Upgrade sqlite jdbc library to 3.36.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.21.0.1</version>
+            <version>3.36.0.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/joda-time/joda-time -->
         <dependency>

--- a/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/query/GetOldestProjectName.java
+++ b/src/main/java/uk/ac/ic/wlgitbridge/bridge/db/sqlite/query/GetOldestProjectName.java
@@ -12,7 +12,8 @@ public class GetOldestProjectName implements SQLQuery<String> {
 
     private static final String GET_OLDEST_PROJECT_NAME =
             "SELECT `name`, MIN(`last_accessed`)\n" +
-            "    FROM `projects`";
+            "    FROM `projects` \n" +
+            "    WHERE `last_accessed` IS NOT NULL;";
 
     @Override
     public String getSQL() {


### PR DESCRIPTION
Also requires a small change to the query that selects the oldest (implicitely un-swapped) project, as the behaviour of `min()` seems to have changed.