### PR TITLE
Add jemalloc/jeprof profiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,26 @@
 
 FROM maven:3-jdk-11 as base
 
-RUN apt-get update && apt-get install -y make git sqlite3 \
- && rm -rf /var/lib/apt/lists
+RUN apt-get update && apt-get install -y make git sqlite3 build-essential dpkg-dev
+
+RUN echo "deb-src http://deb.debian.org/debian buster main" >> /etc/apt/sources.list && \
+    echo "deb-src http://deb.debian.org/debian buster-updates main" >> /etc/apt/sources.list && \
+    echo "deb-src http://security.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list
+
+RUN mkdir -p /build
+WORKDIR /build
+
+RUN apt-get update && \
+    apt-get -y source libjemalloc-dev && \
+    apt-get -y build-dep libjemalloc-dev && \
+    echo "override_dh_auto_configure:" >> jemalloc-5.1.0/debian/rules && \
+    echo "\tdh_auto_configure -- --enable-debug --enable-fill --enable-prof --enable-stat" >> jemalloc-5.1.0/debian/rules && \
+    cat jemalloc-5.1.0/debian/rules
+
+WORKDIR /build/jemalloc-5.1.0
+RUN dpkg-buildpackage
+
+RUN rm -rf /var/lib/apt/lists
 
 COPY vendor/envsubst /opt/envsubst
 RUN chmod +x /opt/envsubst
@@ -41,6 +59,9 @@ RUN mkdir /opt/cdbg && \
 RUN useradd --create-home node
 
 COPY --from=builder /git-bridge.jar /
+COPY --from=builder /build/*.deb /tmp/
+
+RUN dpkg -i /tmp/libjemalloc*.deb
 
 COPY vendor/envsubst /opt/envsubst
 RUN chmod +x /opt/envsubst

--- a/start.sh
+++ b/start.sh
@@ -16,4 +16,6 @@ if [ "$ENABLE_DEBUG_AGENT" == "true" ]; then
   GIT_BRIDGE_JVM_ARGS="-agentpath:/opt/cdbg/cdbg_java_agent.so -Dcom.google.cdbg.module=git-bridge -Dcom.google.cdbg.version=$VERSION ${GIT_BRIDGE_JVM_ARGS}"
 fi
 
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+export MALLOC_CONF=prof:true,lg_prof_interval:30,lg_prof_sample:17,prof_prefix:/tmp/jemalloc
 exec java $GIT_BRIDGE_JVM_ARGS -jar /git-bridge.jar /conf/runtime.json


### PR DESCRIPTION
Installs libjemalloc and enables profiling...

For reference, see:
https://medium.com/swlh/native-memory-the-silent-jvm-killer-595913cba8e7
https://github.com/jeffgriffith/native-jvm-leaks/blob/master/README.md
https://technology.blog.gov.uk/2015/12/11/using-jemalloc-to-get-to-the-bottom-of-a-memory-leak/

We should revert this once we've tracked down what we're looking for.