### PR TITLE
Add binutils and graphviz to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN make package \
 
 FROM openjdk:11-jre
 
-RUN apt-get update && apt-get install -y git sqlite3 procps htop net-tools sockstat \
+RUN apt-get update && apt-get install -y git sqlite3 procps htop net-tools sockstat binutils graphviz \
  && rm -rf /var/lib/apt/lists
 
 # Install Google Cloud Profiler agent


### PR DESCRIPTION
There are unmapped addresses in the output from jeprof when building this locally. Building the profile image on the box might help with this, and objdump and dot (provided by binutils and graphviz) are dependencies for this.

If the profile image can't be generated locally we can still use objdump to help locate what is loaded where.