### PR TITLE
Re-add removed libs, needed by AWS SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,19 @@
             <artifactId>aws-java-sdk</artifactId>
             <version>1.11.274</version>
         </dependency>
+        <!-- API, java.xml.bind module -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+
+        <!-- Runtime, com.sun.xml.bind module -->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
Speculative fix for : https://github.com/overleaf/issues/issues/4524

As advised in https://github.com/aws/aws-sdk-java/issues/1092#issuecomment-749411329 and https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception

The whole `java.xml.bind` package was removed from the JDK in version 11. However, our AWS SDK relies on it being present. This seems to be a known issue upstream, and the workaround is to manually add the required packages.