### PR TITLE
Drop the root log level to "DEBUG"

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -25,7 +25,7 @@
     <logger name="uk.ac.ic.wlgitbridge" level="DEBUG" />
 
     <!-- The root log level determines how much our dependencies put in the logs. -->
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="stdout" />
         <appender-ref ref="stderr" />
     </root>


### PR DESCRIPTION
This allows our dependencies, such as jgit, to log
at the debug level