### PR TITLE
Load Debian's version of jemalloc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,10 @@ RUN make package \
 
 FROM openjdk:11-jre
 
-RUN apt-get update && apt-get install -y git sqlite3 procps htop net-tools sockstat \
+RUN apt-get update && apt-get install -y git sqlite3 procps htop net-tools sockstat libjemalloc2 \
  && rm -rf /var/lib/apt/lists
+
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 # Install Google Cloud Profiler agent
 RUN mkdir -p /opt/cprof && \


### PR DESCRIPTION
jemalloc seems to have a positive impact on memory usage, and may well stop us getting OOMKilled under k8s.

Unfortunately, instead we have seen some crashes with jemalloc at the top of the stack.

This could be to do with our custom build of jemalloc, or the fact that we had profiling enabled. This re-enables jemalloc using Debian's own package, which should be safer.